### PR TITLE
Add quality declaration documents

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,18 @@
+Any contribution that you make to this repository will
+be under the Apache 2 License, as dictated by that
+[license](http://www.apache.org/licenses/LICENSE-2.0.html):
+
+~~~
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+~~~
+
+Contributors must sign-off each commit by adding a `Signed-off-by: ...`
+line to commit messages to certify that they have the right to submit
+the code they are contributing to the project according to the
+[Developer Certificate of Origin (DCO)](https://developercertificate.org/).

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![](https://github.com/open-rmf/rmf_demos/workflows/build/badge.svg)
 ![](https://github.com/open-rmf/rmf_demos/workflows/style/badge.svg)
 
-The Robotics Middleware Framework (RMF) enables interoperability among heterogeneous robot fleets while managing robot traffic that share resources such as space, building infrastructure systems (lifts, doors, etc) and other automation systems within the same facility. RMF also handles task allocation and conflict resolution  among its participants (de-conflicting traffic lanes and other resources). These capabilities are provided by various libraries in [rmf_core](https://github.com/open-rmf/rmf_ros2).
+The Robotics Middleware Framework (RMF) enables interoperability among heterogeneous robot fleets while managing robot traffic that share resources such as space, building infrastructure systems (lifts, doors, etc) and other automation systems within the same facility. RMF also handles task allocation and conflict resolution  among its participants (de-conflicting traffic lanes and other resources). These capabilities are provided by various libraries in [RMF](https://github.com/open-rmf/rmf).
 
 This repository contains demonstrations of the above mentioned capabilities of RMF. It serves as a starting point for working and integrating with RMF.
 

--- a/rmf_demo_panel/README.md
+++ b/rmf_demo_panel/README.md
@@ -1,0 +1,85 @@
+## RMF Demo Panel Installation
+
+Setup `rmf_demo_panel`
+
+Rosdep will automatically install system version of python3-flask and python3-flask-cors. Yet we will download flask-socketio (5.x) separately via pip since the ubutuntu packaged version is too old.
+```bash
+python3 -m pip install flask-socketio
+```
+
+Compilation
+```bash
+cd ~/rmf_demos_ws
+
+# change the npm prefix according to the path to "rmf_demo_panel/static/"
+npm install --prefix src/rmf/rmf_demos/rmf_demo_panel/rmf_demo_panel/static/
+npm run build --prefix src/rmf/rmf_demos/rmf_demo_panel/rmf_demo_panel/static/
+
+colcon build --packages-select rmf_demo_panel
+```
+
+## Run 
+Test Run with office world
+
+1. Start Office World
+```bash
+ros2 launch demos office.launch.xml
+```
+Launch the dashboard
+```
+firefox localhost:5000
+```
+
+## Run Sample Tasks
+
+Open `http://localhost:5000/` on browser.
+
+
+**Submit a list of tasks***
+On the right side column, users are able to select a file which consists of a list of  
+tasks. Example. for office world, load `rmf_demos_tasks/rmf_demo_tasks/office_tasks.json`. 
+Once the tasks are populated in the box, hit submit!
+
+More details on the format for the `.json` file is presented below.
+
+For loop requests:
+```
+{"task_type":"Loop", "start_time":0, "description": {"num_loops":5, "start_name":"coe", "finish_name":"lounge"}}
+```
+
+For delivery requests:
+```
+{"task_type":"Delivery", "start_time":0, "description": {"option": "coke"}}
+```
+Internally, the option `coke` is mapped to a set of parameters required for a delivery request. This mapping can be seen in the `rmf_dashboard_resources/office/dashboard_config.json` file.
+
+For clean requests:
+```
+{"task_type":"Clean", "start_time":0, "description":{"cleaning_zone":"zone_2"}}
+```
+
+**Submit a task***
+User can also submit a single task request via the request form on the top-left side of the page.
+
+The latest robot states and task summaries will be reflected at the bottom portion of the GUI.
+
+## Create your own GUI
+
+There are 2 web-based server running behind the scene, namely:
+
+1. `gui_server` (port `5000`): Providing the static gui to the web client. Non RMF dependent
+2. `api_server` (port `8080`): Hosting all endpoints for gui clients to interact with RMF
+
+To create your own customize GUI, you will only require to create your own `CUSTOM_gui_server` 
+and interact with the existing `api_server`.
+
+## Note
+- Edit the `dashboard_config.json` to configure the input of the Demo World GUI Task Submission.
+The dashboard config file is located here: `rmf_dashboard_resources/$WORLD/dashboard_config.json`.
+- server ip is configurable via `WEB_SERVER_IP_ADDRESS` in the `dashboard.launch.xml`
+- The `api_server` outputs and stores a summarized log: `web_server.log`.
+- cancel task will not be working. A fully functional cancel will be introduced in a future PR.
+
+## Quality Declaration
+
+This package claims to be in the **Quality Level 4** category, see the [Quality Declaration](./QUALITY_DECLARATION.md) for more details.

--- a/rmf_demos/QUALITY_DECLARATION.md
+++ b/rmf_demos/QUALITY_DECLARATION.md
@@ -1,0 +1,194 @@
+This document is a declaration of software quality for the `rmf_demos` package, based on the guidelines in [REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+# `rmf_demos` Quality Declaration
+
+The package `rmf_demos` claims to be in the **Quality Level 4** category.
+The main rationale for this claim its its status as a collection of demonstration launch files.
+
+Below are the detailed rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 3 in REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+## Version Policy [1]
+
+### Version Scheme [1.i]
+
+`rmf_demos` uses `semver` according to the recommendation for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#versioning).
+
+### Version Stability [1.ii]
+
+`rmf_demos` is at a stable version, i.e. `>= 1.0.0`.
+The current version can be found in its [package.xml](package.xml), and its change history can be found in its [CHANGELOG](CHANGELOG.rst).
+
+### Public API Declaration [1.iii]
+
+`rmf_demos` does not have a public API.
+
+### API Stability Policy [1.iv]
+
+`rmf_demos` does not have a public API.
+
+### ABI Stability Policy [1.v]
+
+`rmf_demos` does not have a public API.
+
+### API and ABI Stability Within a Released ROS Distribution [1.vi]
+
+`rmf_demos` does not have a public API.
+
+## Change Control Process [2]
+
+`rmf_demos` follows the recommended guidelines for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#package-requirements).
+
+### Change Requests [2.i]
+
+`rmf_demos` requires that all changes occur through a pull request.
+
+### Contributor Origin [2.ii]
+
+`rmf_demos` uses DCO as its confirmation of contributor origin policy. More information can be found in [CONTRIBUTING](../CONTRIBUTING.md).
+
+### Peer Review Policy [2.iii]
+
+All pull requests must have at least 1 peer review.
+
+### Continuous Integration [2.iv]
+
+All pull requests must pass CI on all platforms supported by RMF.
+The CI checks only that the package builds.
+The most recent CI results can be seen on [the workflow page](https://github.com/open-rmf/rmf_demos/actions).
+
+### Documentation Policy [2.v]
+
+All pull requests must resolve related documentation changes before merging.
+
+## Documentation [3]
+
+### Feature Documentation [3.i]
+
+`rmf_demos` is documented in the [parent repository's README.md file](../README.md).
+
+### Public API Documentation [3.ii]
+
+`rmf_demos` does not have a public API.
+
+### License [3.iii]
+
+The license for `rmf_demos` is Apache 2.0, the type is declared in the [package.xml](package.xml) manifest file, and a full copy of the license is in the repository level [LICENSE](../LICENSE) file.
+
+There are no source files that are currently copyrighted in this package so files are not checked for abbreviated license statements.
+
+### Copyright Statement [3.iv]
+
+There are no copyrighted source files in this package.
+
+### Quality declaration document [3.v]
+
+This quality declaration is linked in the [README file](README.md).
+
+This quality declaration has not been externally peer-reviewed and is not registered on any Level 3 lists.
+
+## Testing [4]
+
+### Feature Testing [4.i]
+
+`rmf_demos` is a package providing strictly launch files and therefore does not require associated tests.
+
+### Public API Testing [4.ii]
+
+`rmf_demos` is a package providing strictly launch files and therefore does not require associated tests.
+
+### Coverage [4.iii]
+
+`rmf_demos` is a package providing strictly launch files and therefore does not require associated tests.
+
+### Performance [4.iv]
+
+`rmf_demos` is a package providing strictly launch files and therefore does not require associated tests.
+
+### Linters and Static Analysis [4.v]
+
+`rmf_demos` does not use the [standard linters and static analysis tools](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#linters).
+
+## Dependencies [5]
+
+### Direct Runtime ROS Dependencies [5.i]
+
+`rmf_demos` has the following runtime ROS dependencies.
+
+#### rmf_demo_maps
+
+`rmf_demo_maps` is at [**Quality Level 4**](../rmf_demo_maps/QUALITY_DECLARATION.md).
+
+#### rmf_traffic_ros2
+
+`rmf_traffic_ros2` is at [**Quality Level 4**](https://github.com/open-rmf/rmf_ros2/blob/main/rmf_traffic_ros2/QUALITY_DECLARATION.md).
+
+#### rmf_fleet_adapter
+
+`rmf_fleet_adapter` is at [**Quality Level 4**](https://github.com/open-rmf/rmf_ros2/blob/main/rmf_fleet_adapter/QUALITY_DECLARATION.md).
+
+#### building_map_tools
+
+`building_map_tools` is at [**Quality Level 4**](https://github.com/open-rmf/rmf_traffic_editor/blob/main/rmf_building_map_tools/QUALITY_DECLARATION.md).
+
+#### building_gazebo_plugins
+
+`building_gazebo_plugins` is at [**Quality Level 4**](https://github.com/open-rmf/rmf_simulation/blob/main/rmf_building_sim_gazebo_plugins/QUALITY_DECLARATION.md).
+
+#### rmf_visualization
+
+`rmf_visualization` is at [**Quality Level 4**](https://github.com/open-rmf/rmf_visualization/blob/main/rmf_visualization/QUALITY_DECLARATION.md).
+
+#### gazebo_ros_pkgs
+
+`gazebo_ros_pkgs` does not declare a Quality Level.
+It is assumed to be at least **Quality Level 4** based on its widespread use.
+
+#### rmf_demo_assets
+
+`rmf_demo_assets` is at [**Quality Level 4**](../rmf_demo_assets/QUALITY_DECLARATION.md).
+
+#### rmf_gazebo_plugins
+
+`rmf_gazebo_plugins` is at [**Quality Level 4**](https://github.com/open-rmf/rmf_simulation/blob/main/rmf_robot_sim_gazebo_plugins/QUALITY_DECLARATION.md).
+
+#### rmf_demo_tasks
+
+`rmf_demo_tasks` is at [**Quality Level 4**](../rmf_demos_tasks/QUALITY_DECLARATION.md).
+
+#### rviz2
+
+`rviz2` does not declare a Quality Level.
+It is assumed tobe at **Quality Level 4** based on its widespread use.
+
+#### joy
+
+`joy` does not declare a Quality Level.
+It is assumed tobe at **Quality Level 4** based on its widespread use.
+
+#### teleop_twist_joy
+
+`teleop_twist_joy` does not declare a Quality Level.
+It is assumed tobe at **Quality Level 4** based on its widespread use.
+
+#### launch_xml
+
+`launch_xml` does not declare a Quality Level.
+It is assumed tobe at **Quality Level 4** based on its widespread use.
+
+### Optional Direct Runtime ROS Dependencies [5.ii]
+
+`rmf_demos` does not have any optional direct runtime ROS dependencies.
+
+### Direct Runtime non-ROS Dependency [5.iii]
+
+`rmf_demos` does not have any runtime non-ROS dependencies.
+
+## Platform Support [6]
+
+As a pure message and service definitions package, `rmf_demos` supports all of the tier 1 platforms as described in [REP-2000](https://www.ros.org/reps/rep-2000.html#support-tiers), but does not currently test each change against all of them.
+
+## Security [7]
+
+### Vulnerability Disclosure Policy [7.i]
+
+This package conforms to the Vulnerability Disclosure Policy in [REP-2006](https://www.ros.org/reps/rep-2006.html).

--- a/rmf_demos/README.md
+++ b/rmf_demos/README.md
@@ -1,0 +1,7 @@
+# rmf_demos
+
+This package provides launch files and shell scripts demonstrating how to build and start systems using RMF.
+
+## Quality Declaration
+
+This package claims to be in the **Quality Level 4** category, see the [Quality Declaration](./QUALITY_DECLARATION.md) for more details.

--- a/rmf_demos_dashboard_resources/QUALITY_DECLARATION.md
+++ b/rmf_demos_dashboard_resources/QUALITY_DECLARATION.md
@@ -1,0 +1,132 @@
+This document is a declaration of software quality for the `rmf_demos_dashboard_resources` package, based on the guidelines in [REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+# `rmf_demos_dashboard_resources` Quality Declaration
+
+The package `rmf_demos_dashboard_resources` claims to be in the **Quality Level 3** category.
+
+Below are the detailed rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 3 in REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+## Version Policy [1]
+
+### Version Scheme [1.i]
+
+`rmf_demos_dashboard_resources` uses `semver` according to the recommendation for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#versioning).
+
+### Version Stability [1.ii]
+
+`rmf_demos_dashboard_resources` is at a stable version, i.e. `>= 1.0.0`.
+The current version can be found in its [package.xml](package.xml), and its change history can be found in its [CHANGELOG](CHANGELOG.rst).
+
+### Public API Declaration [1.iii]
+
+`rmf_demos_dashboard_resources` does not have a public API.
+
+### API Stability Policy [1.iv]
+
+`rmf_demos_dashboard_resources` does not have a public API.
+
+### ABI Stability Policy [1.v]
+
+`rmf_demos_dashboard_resources` does not have a public API.
+
+### API and ABI Stability Within a Released ROS Distribution [1.vi]
+
+`rmf_demos_dashboard_resources` does not have a public API.
+
+## Change Control Process [2]
+
+`rmf_demos_dashboard_resources` follows the recommended guidelines for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#package-requirements).
+
+### Change Requests [2.i]
+
+`rmf_demos_dashboard_resources` requires that all changes occur through a pull request.
+
+### Contributor Origin [2.ii]
+
+`rmf_demos_dashboard_resources` uses DCO as its confirmation of contributor origin policy. More information can be found in [CONTRIBUTING](../CONTRIBUTING.md).
+
+### Peer Review Policy [2.iii]
+
+All pull requests must have at least 1 peer review.
+
+### Continuous Integration [2.iv]
+
+All pull requests must pass CI on all platforms supported by RMF.
+The CI checks only that the package builds.
+The most recent CI results can be seen on [the workflow page](https://github.com/open-rmf/rmf_demos/actions).
+
+### Documentation Policy [2.v]
+
+All pull requests must resolve related documentation changes before merging.
+
+## Documentation [3]
+
+### Feature Documentation [3.i]
+
+`rmf_demos_dashboard_resources` is documented in the [parent repository's README.md file](https://github.com/open-rmf/rmf_demos/blob/main/README.md).
+
+### Public API Documentation [3.ii]
+
+`rmf_demos_dashboard_resources` does not have a public API.
+
+### License [3.iii]
+
+The license for `rmf_demos_dashboard_resources` is Apache 2.0, the type is declared in the [package.xml](package.xml) manifest file, and a full copy of the license is in the repository level [LICENSE](../LICENSE) file.
+
+There are no source files that are currently copyrighted in this package so files are not checked for abbreviated license statements.
+
+### Copyright Statement [3.iv]
+
+There are no copyrighted source files in this package.
+
+### Quality declaration document [3.v]
+
+This quality declaration is linked in the [README file](README.md).
+
+This quality declaration has not been externally peer-reviewed and is not registered on any Level 3 lists.
+
+## Testing [4]
+
+### Feature Testing [4.i]
+
+`rmf_demos_dashboard_resources` is a package providing strictly resource files and therefore does not require associated tests.
+
+### Public API Testing [4.ii]
+
+`rmf_demos_dashboard_resources` is a package providing strictly resource files and therefore does not require associated tests.
+
+### Coverage [4.iii]
+
+`rmf_demos_dashboard_resources` is a package providing strictly resource files and therefore does not require associated tests.
+
+### Performance [4.iv]
+
+`rmf_demos_dashboard_resources` is a package providing strictly resource files and therefore does not require associated tests.
+
+### Linters and Static Analysis [4.v]
+
+`rmf_demos_dashboard_resources` has no files that require linting or static analysis.
+
+## Dependencies [5]
+
+### Direct Runtime ROS Dependencies [5.i]
+
+`rmf_demos_dashboard_resources` does not have any required direct runtime ROS dependencies.
+
+### Optional Direct Runtime ROS Dependencies [5.ii]
+
+`rmf_demos_dashboard_resources` does not have any optional direct runtime ROS dependencies.
+
+### Direct Runtime non-ROS Dependency [5.iii]
+
+`rmf_demos_dashboard_resources` does not have any runtime non-ROS dependencies.
+
+## Platform Support [6]
+
+As a pure resource package, `rmf_demos_dashboard_resources` supports all of the tier 1 platforms as described in [REP-2000](https://www.ros.org/reps/rep-2000.html#support-tiers), but does not currently test each change against all of them.
+
+## Security [7]
+
+### Vulnerability Disclosure Policy [7.i]
+
+This package conforms to the Vulnerability Disclosure Policy in [REP-2006](https://www.ros.org/reps/rep-2006.html).

--- a/rmf_demos_dashboard_resources/README.md
+++ b/rmf_demos_dashboard_resources/README.md
@@ -1,0 +1,7 @@
+# rmf\_dashboard\_resources
+
+This package provides resources for the RMF dashboard.
+
+## Quality Declaration
+
+This package claims to be in the **Quality Level 3** category, see the [Quality Declaration](./QUALITY_DECLARATION.md) for more details.

--- a/rmf_demos_maps/QUALITY_DECLARATION.md
+++ b/rmf_demos_maps/QUALITY_DECLARATION.md
@@ -1,0 +1,131 @@
+This document is a declaration of software quality for the `rmf_demo_maps` package, based on the guidelines in [REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+# `rmf_demo_maps` Quality Declaration
+
+The package `rmf_demo_maps` claims to be in the **Quality Level 3** category.
+The main rationale for this claim is its status as a collection of demonstration map files.
+
+Below are the detailed rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 3 in REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+## Version Policy [1]
+
+### Version Scheme [1.i]
+
+`rmf_demo_maps` uses `semver` according to the recommendation for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#versioning).
+
+### Version Stability [1.ii]
+
+`rmf_demo_maps` is at a stable version, i.e. `>= 1.0.0`.
+The current version can be found in its [package.xml](package.xml), and its change history can be found in its [CHANGELOG](CHANGELOG.rst).
+
+### Public API Declaration [1.iii]
+
+`rmf_demo_maps` does not have a public API.
+
+### API Stability Policy [1.iv]
+
+`rmf_demo_maps` does not have a public API.
+
+### ABI Stability Policy [1.v]
+
+`rmf_demo_maps` does not have a public API.
+
+### API and ABI Stability Within a Released ROS Distribution [1.vi]
+
+`rmf_demo_maps` does not have a public API.
+
+## Change Control Process [2]
+
+`rmf_demo_maps` follows the recommended guidelines for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#package-requirements).
+
+### Change Requests [2.i]
+
+`rmf_demo_maps` requires that all changes occur through a pull request.
+
+### Contributor Origin [2.ii]
+
+`rmf_demo_maps` uses DCO as its confirmation of contributor origin policy. More information can be found in [CONTRIBUTING](../CONTRIBUTING.md).
+
+### Peer Review Policy [2.iii]
+
+All pull requests must have at least 1 peer review.
+
+### Continuous Integration [2.iv]
+
+All pull requests must pass CI on all platforms supported by RMF.
+The CI checks only that the package builds.
+The most recent CI results can be seen on [the workflow page](https://github.com/open-rmf/rmf_demos/actions).
+
+### Documentation Policy [2.v]
+
+All pull requests must resolve related documentation changes before merging.
+
+## Documentation [3]
+
+### Feature Documentation [3.i]
+
+`rmf_demo_maps` is documented in the [parent repository's README.md file](../README.md).
+
+### Public API Documentation [3.ii]
+
+`rmf_demo_maps` does not have a public API.
+
+### License [3.iii]
+
+The license for `rmf_demo_maps` is Apache 2.0, the type is declared in the [package.xml](package.xml) manifest file, and a full copy of the license is in the repository level [LICENSE](../LICENSE) file.
+
+There are no source files that are currently copyrighted in this package so files are not checked for abbreviated license statements.
+
+### Copyright Statement [3.iv]
+
+There are no copyrighted source files in this package.
+
+### Quality declaration document [3.v]
+
+This quality declaration has not been externally peer-reviewed and is not registered on any Level 3 lists.
+
+## Testing [4]
+
+### Feature Testing [4.i]
+
+`rmf_demo_maps` is a package providing strictly resource files and therefore does not require associated tests.
+
+### Public API Testing [4.ii]
+
+`rmf_demo_maps` is a package providing strictly resource files and therefore does not require associated tests.
+
+### Coverage [4.iii]
+
+`rmf_demo_maps` is a package providing strictly resource files and therefore does not require associated tests.
+
+### Performance [4.iv]
+
+`rmf_demo_maps` is a package providing strictly resource files and therefore does not require associated tests.
+
+### Linters and Static Analysis [4.v]
+
+`rmf_demo_maps` has no files that require linting or static analysis.
+
+## Dependencies [5]
+
+### Direct Runtime ROS Dependencies [5.i]
+
+`rmf_demo_maps` does not have any required direct runtime ROS dependencies.
+
+### Optional Direct Runtime ROS Dependencies [5.ii]
+
+`rmf_demo_maps` does not have any optional direct runtime ROS dependencies.
+
+### Direct Runtime non-ROS Dependency [5.iii]
+
+`rmf_demo_maps` does not have any runtime non-ROS dependencies.
+
+## Platform Support [6]
+
+As a pure resource package, `rmf_demo_maps` supports all of the tier 1 platforms as described in [REP-2000](https://www.ros.org/reps/rep-2000.html#support-tiers), but does not currently test each change against all of them.
+
+## Security [7]
+
+### Vulnerability Disclosure Policy [7.i]
+
+This package conforms to the Vulnerability Disclosure Policy in [REP-2006](https://www.ros.org/reps/rep-2006.html).

--- a/rmf_demos_maps/README.md
+++ b/rmf_demos_maps/README.md
@@ -1,0 +1,7 @@
+# rmf\_demo\_maps
+
+This package provides maps for the RMF demos.
+
+## Quality Declaration
+
+This package claims to be in the **Quality Level 3** category, see the [Quality Declaration](./QUALITY_DECLARATION.md) for more details.

--- a/rmf_demos_panel/QUALITY_DECLARATION.md
+++ b/rmf_demos_panel/QUALITY_DECLARATION.md
@@ -1,0 +1,150 @@
+This document is a declaration of software quality for the `rmf_demo_panel` package, based on the guidelines in [REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+# `rmf_demo_panel` Quality Declaration
+
+The package `rmf_demo_panel` claims to be in the **Quality Level 4** category.
+
+Below are the detailed rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 3 in REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+## Version Policy [1]
+
+### Version Scheme [1.i]
+
+`rmf_demo_panel` uses `semver` according to the recommendation for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#versioning).
+
+### Version Stability [1.ii]
+
+`rmf_demo_panel` is at a stable version, i.e. `>= 1.0.0`.
+The current version can be found in its [package.xml](package.xml), and its change history can be found in its [CHANGELOG](CHANGELOG.rst).
+
+### Public API Declaration [1.iii]
+
+`rmf_demo_panel` does not have a public API.
+
+### API Stability Policy [1.iv]
+
+`rmf_demo_panel` does not have a public API.
+
+### ABI Stability Policy [1.v]
+
+`rmf_demo_panel` does not have a public API.
+
+### API and ABI Stability Within a Released ROS Distribution [1.vi]
+
+`rmf_demo_panel` does not have a public API.
+
+## Change Control Process [2]
+
+`rmf_demo_panel` follows the recommended guidelines for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#package-requirements).
+
+### Change Requests [2.i]
+
+`rmf_demo_panel` requires that all changes occur through a pull request.
+
+### Contributor Origin [2.ii]
+
+`rmf_demo_panel` uses DCO as its confirmation of contributor origin policy. More information can be found in [CONTRIBUTING](../CONTRIBUTING.md).
+
+### Peer Review Policy [2.iii]
+
+All pull requests must have at least 1 peer review.
+
+### Continuous Integration [2.iv]
+
+All pull requests must pass CI on all platforms supported by RMF.
+The CI checks only that the package builds.
+The most recent CI results can be seen on [the workflow page](https://github.com/open-rmf/rmf_demos/actions).
+
+### Documentation Policy [2.v]
+
+All pull requests must resolve related documentation changes before merging.
+
+## Documentation [3]
+
+### Feature Documentation [3.i]
+
+`rmf_demo_panel` is documented in the [parent repository's README.md file](../README.md) and in [its own README.md file](README.md).
+
+### Public API Documentation [3.ii]
+
+`rmf_demo_panel` does not have a public API.
+
+### License [3.iii]
+
+The license for `rmf_demo_panel` is Apache 2.0, the type is declared in the [package.xml](package.xml) manifest file, and a full copy of the license is in the repository level [LICENSE](../LICENSE) file.
+
+### Copyright Statement [3.iv]
+
+The copyright holders each provide a statement of copyright in each source code file in `rmf_demo_panel`.
+
+### Quality declaration document [3.v]
+
+This quality declaration is linked in the [README file](README.md).
+
+This quality declaration has not been externally peer-reviewed and is not registered on any Level 4 lists.
+
+## Testing [4]
+
+### Feature Testing [4.i]
+
+`rmf_demo_panel` does not have feature tests.
+
+### Public API Testing [4.ii]
+
+`rmf_demo_panel` does not have API tests.
+
+### Coverage [4.iii]
+
+`rmf_demo_panel` does not measure code coverage of tests.
+
+### Performance [4.iv]
+
+`rmf_demo_panel` does not test performance.
+
+### Linters and Static Analysis [4.v]
+
+`rmf_demo_panel` does not utilise linters or static analysis tools.
+
+## Dependencies [5]
+
+### Direct Runtime ROS Dependencies [5.i]
+
+`rmf_demo_panel` has the following direct runtime ROS dependencies.
+
+#### rmf\_fleet\_msgs
+
+`rmf_fleet_msgs` is [**Quality Level 3**](https://github.com/open-rmf/rmf_internal_msgs/blob/main/rmf_fleet_msgs/QUALITY_DECLARATION.md).
+
+#### rmf\_task\_msgs
+
+`rmf_task_msgs` is [**Quality Level 3**](https://github.com/open-rmf/rmf_internal_msgs/blob/main/rmf_task_msgs/QUALITY_DECLARATION.md).
+
+#### rmf\_demos\_dashboard\_resources
+
+`rmf_demos_dashboard_resources` is [**Quality Level 3**](../rmf_demos_dashboard_resources/QUALITY_DECLARATION.md).
+
+### Optional Direct Runtime ROS Dependencies [5.ii]
+
+`rmf_demo_panel` does not have any optional direct runtime ROS dependencies.
+
+### Direct Runtime non-ROS Dependency [5.iii]
+
+`rmf_demo_panel` has the following direct runtime non-ROS dependencies.
+
+#### python3-flask
+
+`python3-flask` is assumed to be Quality Level 4.
+
+#### python3-flask-cors
+
+`python3-flask-cors` is assumed to be Quality Level 4.
+
+## Platform Support [6]
+
+`rmf_demo_panel` supports all of the tier 1 platforms as described in [REP-2000](https://www.ros.org/reps/rep-2000.html#support-tiers), but does not currently test each change against all of them.
+
+## Security [7]
+
+### Vulnerability Disclosure Policy [7.i]
+
+This package conforms to the Vulnerability Disclosure Policy in [REP-2006](https://www.ros.org/reps/rep-2006.html).

--- a/rmf_demos_tasks/QUALITY_DECLARATION.md
+++ b/rmf_demos_tasks/QUALITY_DECLARATION.md
@@ -1,0 +1,147 @@
+This document is a declaration of software quality for the `rmf_demo_tasks` package, based on the guidelines in [REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+# `rmf_demo_tasks` Quality Declaration
+
+The package `rmf_demo_tasks` claims to be in the **Quality Level 4** category.
+The main rationale for this claim its its status as a collection of demonstration script files.
+
+Below are the detailed rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 4 in REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+## Version Policy [1]
+
+### Version Scheme [1.i]
+
+`rmf_demo_tasks` uses `semver` according to the recommendation for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#versioning).
+
+### Version Stability [1.ii]
+
+`rmf_demo_tasks` is at a stable version, i.e. `>= 1.0.0`.
+The current version can be found in its [package.xml](package.xml), and its change history can be found in its [CHANGELOG](CHANGELOG.rst).
+
+### Public API Declaration [1.iii]
+
+`rmf_demo_tasks` does not have a public API.
+
+### API Stability Policy [1.iv]
+
+`rmf_demo_tasks` does not have a public API.
+
+### ABI Stability Policy [1.v]
+
+`rmf_demo_tasks` does not have a public API.
+
+### API and ABI Stability Within a Released ROS Distribution [1.vi]
+
+`rmf_demo_tasks` does not have a public API.
+
+## Change Control Process [2]
+
+`rmf_demo_tasks` follows the recommended guidelines for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#package-requirements).
+
+### Change Requests [2.i]
+
+`rmf_demo_tasks` requires that all changes occur through a pull request.
+
+### Contributor Origin [2.ii]
+
+`rmf_demo_tasks` uses DCO as its confirmation of contributor origin policy. More information can be found in [CONTRIBUTING](../CONTRIBUTING.md).
+
+### Peer Review Policy [2.iii]
+
+All pull requests must have at least 1 peer review.
+
+### Continuous Integration [2.iv]
+
+All pull requests must pass CI on all platforms supported by RMF.
+The CI checks only that the package builds.
+The most recent CI results can be seen on [the workflow page](https://github.com/open-rmf/rmf_demos/actions).
+
+### Documentation Policy [2.v]
+
+All pull requests must resolve related documentation changes before merging.
+
+## Documentation [3]
+
+### Feature Documentation [3.i]
+
+`rmf_demo_tasks` is documented in the [parent repository's README.md file](../README.md).
+
+### Public API Documentation [3.ii]
+
+`rmf_demo_tasks` does not have a public API.
+
+### License [3.iii]
+
+The license for `rmf_demo_tasks` is Apache 2.0, the type is declared in the [package.xml](package.xml) manifest file, and a full copy of the license is in the repository level [LICENSE](../LICENSE) file.
+
+### Copyright Statement [3.iv]
+
+The copyright holders each provide a statement of copyright in each source code file in `rmf_demo_tasks`.
+
+### Quality declaration document [3.v]
+
+This quality declaration is linked in the [README file](README.md).
+
+This quality declaration has not been externally peer-reviewed and is not registered on any Level 4 lists.
+
+## Testing [4]
+
+### Feature Testing [4.i]
+
+`rmf_demo_tasks` is a package providing strictly demonstration script files and therefore does not require associated tests.
+
+### Public API Testing [4.ii]
+
+`rmf_demo_tasks` is a package providing strictly demonstration script files and therefore does not require associated tests.
+
+### Coverage [4.iii]
+
+`rmf_demo_tasks` is a package providing strictly demonstration script files and therefore does not require associated tests.
+
+### Performance [4.iv]
+
+`rmf_demo_tasks` is a package providing strictly demonstration script files and therefore does not require associated tests.
+
+### Linters and Static Analysis [4.v]
+
+`rmf_demo_tasks` does not use the standard linters and static analysis tools for its CMake code to ensure it follows the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#linters).
+
+## Dependencies [5]
+
+### Direct Runtime ROS Dependencies [5.i]
+
+`rmf_demo_tasks` has the following direct runtime ROS dependencies.
+
+#### rmf\_fleet\_msgs
+
+`rmf_fleet_msgs` is [**Quality Level 3**](https://github.com/open-rmf/rmf_internal_msgs/blob/main/rmf_fleet_msgs/QUALITY_DECLARATION.md).
+
+#### rmf\_task\_msgs
+
+`rmf_task_msgs` is [**Quality Level 3**](https://github.com/open-rmf/rmf_internal_msgs/blob/main/rmf_task_msgs/QUALITY_DECLARATION.md).
+
+#### rmf\_lift\_msgs
+
+`rmf_lift_msgs` is [**Quality Level 3**](https://github.com/open-rmf/rmf_internal_msgs/blob/main/rmf_list_msgs/QUALITY_DECLARATION.md).
+
+#### rmf\_dispenser\_msgs
+
+`rmf_dispenser_msgs`` is [**Quality Level 3**](https://github.com/open-rmf/rmf_internal_msgs/blob/main/rmf_dispenser_msgs/QUALITY_DECLARATION.md).
+
+### Optional Direct Runtime ROS Dependencies [5.ii]
+
+`rmf_demo_tasks` does not have any optional direct runtime ROS dependencies.
+
+### Direct Runtime non-ROS Dependency [5.iii]
+
+`rmf_demo_tasks` does not have any runtime non-ROS dependencies.
+
+## Platform Support [6]
+
+As a pure resource package, `rmf_demo_tasks` supports all of the tier 1 platforms as described in [REP-2000](https://www.ros.org/reps/rep-2000.html#support-tiers), but does not currently test each change against all of them.
+
+## Security [7]
+
+### Vulnerability Disclosure Policy [7.i]
+
+This package conforms to the Vulnerability Disclosure Policy in [REP-2006](https://www.ros.org/reps/rep-2006.html).

--- a/rmf_demos_tasks/README.md
+++ b/rmf_demos_tasks/README.md
@@ -1,0 +1,7 @@
+# rmf\_demo\_tasks
+
+This package provides scripts used in the RMF demos to demonstrate the tasks that may be requested of a robot.
+
+## Quality Declaration
+
+This package claims to be in the **Quality Level 4** category, see the [Quality Declaration](./QUALITY_DECLARATION.md) for more details.


### PR DESCRIPTION
This PR adds [quality declaration documents](https://www.ros.org/reps/rep-2004.html) and (where necessary) basic README files too all packages in `rmf_demos`.

The resource packages meet the requirements to be Quality Level 3. All source-code-containing packages are currently QL4.