### PR TITLE
Feature/setup ci

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,3 +43,13 @@ jobs:
         cd rmf_demos_ws
         source /opt/ros/foxy/setup.bash
         colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release -DNO_DOWNLOAD_MODELS=True
+    # Optional: Also compile the rmf_demos_panel
+    - uses: actions/setup-node@v2
+      with:
+        node-version: '14'
+        check-latest: true
+    - name: build-panel
+      run: |
+        cd rmf_demos_ws/src/rmf/rmf_demos/rmf_demos_panel/rmf_demos_panel/static
+        npm install
+        npm run build

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,45 @@
+name: build
+on: [push, pull_request]
+jobs:
+
+  ros2:
+    runs-on: ubuntu-20.04
+    container:
+      image: docker://ros:foxy-ros-base-focal
+    steps:
+    - name: non-ros-deps
+      run: |
+        sudo apt update
+        sudo apt install -y wget
+        sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list'
+        wget https://packages.osrfoundation.org/gazebo.key -O - | apt-key add -
+        
+        sudo apt update && sudo apt install \
+          git cmake python3-vcstool curl \
+          qt5-default \
+          python3-shapely python3-yaml python3-requests \
+          ignition-dome \
+          -y
+    - name: create-ws
+      run: |
+        mkdir -p rmf_demos_ws/src
+    - name: checkout
+      uses: actions/checkout@v2
+      with:
+        path: rmf_demos_ws/src/rmf/rmf_demos
+    - name: workspace
+      run: |
+        cd rmf_demos_ws
+        wget https://raw.githubusercontent.com/open-rmf/rmf/main/rmf.repos
+        vcs import src < rmf.repos --skip-existing
+    - name: ros-deps
+      run: |
+        cd rmf_demos_ws
+        rosdep update
+        rosdep install --from-paths src --ignore-src --rosdistro foxy -yr
+    - name: build
+      shell: bash
+      run: |
+        cd rmf_demos_ws
+        source /opt/ros/foxy/setup.bash
+        colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release -DNO_DOWNLOAD_MODELS=True

--- a/.github/workflows/gh_page.yml
+++ b/.github/workflows/gh_page.yml
@@ -2,7 +2,7 @@ name: Deploy rmf_panel gh_page
 on:
   push:
     branches:
-      - master
+      - main
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
@@ -14,7 +14,7 @@ jobs:
         with:
           node-version: '14'
           check-latest: true
-      - name: "Install and Build"
+      - name: build-panel
         run: |
           cd rmf_demos/rmf_demos_panel/rmf_demos_panel/static
           npm install

--- a/.github/workflows/gh_page.yml
+++ b/.github/workflows/gh_page.yml
@@ -1,0 +1,27 @@
+name: Deploy rmf_panel gh_page
+on:
+  push:
+    branches:
+      - master
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          path: rmf_demos
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+          check-latest: true
+      - name: "Install and Build"
+        run: |
+          cd rmf_demos/rmf_demos_panel/rmf_demos_panel/static
+          npm install
+          npm run build
+      - name: deploy_page
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: rmf_demos/rmf_demos_panel/rmf_demos_panel/static/dist
+          destination_dir: v1.0.0 # Change the version of webpack: "app.bundle.js"

--- a/.github/workflows/gh_page.yml
+++ b/.github/workflows/gh_page.yml
@@ -1,4 +1,4 @@
-name: Deploy rmf_panel gh_page
+name: deploy-gh_page
 on:
   push:
     branches:

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -1,0 +1,25 @@
+name: style
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    container:
+      image: docker://ros:foxy-ros-base-focal
+    steps:
+    - uses: actions/checkout@v2
+    - name: deps
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install wget pycodestyle
+    #  Note: Enable this if only cpp files are available for style check
+    # - name: rmf_uncrustify
+    #   shell: bash
+    #   run: |
+    #     wget https://raw.githubusercontent.com/open-rmf/rmf_utils/master/rmf_utils/test/format/rmf_code_style.cfg
+    #     source /opt/ros/foxy/setup.bash
+    #     ament_uncrustify -c rmf_code_style.cfg
+    - name: pycodestyle
+      shell: bash
+      run: |
+        pycodestyle .

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The RMF panel is a web based dashboard for interacting with RMF. It allows users
 There are two main modes of submitting tasks to RMF via the Panel:
 
 1. Submit a Task: Used to submit a single task. The user is required to first select a request type from the drop down menu. Depending on the type selected, additional fields specify to the type will need to be populated. The user can then specify the `start time` for the task before clicking `Submit Request`. 
-2. Submit a List of Tasks: Used to submit a batch of tasks. A `.json` file containing a list of tasks may be loaded via the `Choose file` button. Some example files are found in `rmf_demos_tasks/rmf_demos_tasks`. Once loaded, clicking the `Submit Task List` button will automatically assign the various tasks to available robots.
+2. Submit a List of Tasks: Used to submit a batch of tasks. A `.json` file containing a list of tasks may be loaded via the `Choose file` button. Some example files are found in `rmf_demos_panel/task_lists`. Once loaded, clicking the `Submit Task List` button will automatically assign the various tasks to available robots.
 
 Users may switch between different tabs on the top-left corner of the Panel when running the relevant demo world. More information on configuring the panel can be found [here](rmf_demos_panel/README.md)
 
@@ -79,7 +79,7 @@ ros2 run rmf_demos_tasks dispatch_delivery -p pantry -pd coke_dispenser -d hardw
 ![](docs/media/delivery_request.gif)
 
 To send loop requests, select `Loop` from the `Select a request type` dropdown list. Choose desired start and end locations and click submit.
-To run a scenario with multiple task requests, load `office_tasks.json` from `rmf_demos_tasks/rmf_demos_tasks` in the `Submit a list of tasks` section. This should populate the preview window with a list of tasks. Click submit and watch the demonstration unfold.
+To run a scenario with multiple task requests, load `office_tasks.json` from `rmf_demos_panel/task_lists` in the `Submit a list of tasks` section. This should populate the preview window with a list of tasks. Click submit and watch the demonstration unfold.
 
 ![](docs/media/loop_request.gif)
 

--- a/rmf_demos_panel/README.md
+++ b/rmf_demos_panel/README.md
@@ -32,10 +32,10 @@ required when you are running the `gui_server` for the first time.
 
 ---
 
-## Development Mode (local)
+## Development Mode (local npm compilation)
 
-This development mode is useful for personel who are interested to compile a local React Gui 
-Bundle. **Else you can skip this portion.**.
+Currently the webpack bundle is located here `https://open-rmf.github.io/rmf_demos/VERSION/app.bundle.js`. Thus this is useful
+for personnel who would like to compile a local react webpack bundle (for testing). **Else you can skip this portion.**
 
 ### Dependencies: 
  - npm (node version > 12, see: [node](https://nodejs.org/en/download/package-manager/))
@@ -53,22 +53,23 @@ colcon build --packages-select rmf_demos_panel
 
 ### API Endpoints
 
-Endpoints | Method | body | Description
+Endpoints | Type | Parameters | Description
 --- | --- | --- | ---
-/submit_task | POST | task description json | This supports submission of task
-/cancel_task | POST | task_id string | Cancel a existing task
-/task_list | GET | NULL | Get list of task status in RMF
-/robot_list | GET | NULL | Get list of Robot states in RMF
-/task_status | SocketIO | NULL | Constant broadcast task list
-/robot_states | SocketIO | NULL | Constant broadcast robot list
+/submit_task | POST | task description json | This supports submission of task. This response with an assigned task_id is the task is accepted
+/cancel_task | POST | task_id string | Cancel an existing task in rmf.
+/task_list | GET | NA | Get list of task status in RMF (include active and terminated tasks)
+/robot_list | GET | NA | Get list of Robot states in RMF
+/task_status | SocketIO | NA | Constant broadcast of task list
+/robot_states | SocketIO | NA | Constant broadcast of robot list
 
-#### Simple CURL Test on a seperate terminal
+#### Simple CURL Test
 
 ```bash
 # Submit Task (POST)
 curl -X POST http://localhost:8080/submit_task \
 -d '{"task_type":"Loop", "start_time":0, "description": {"start_name": "coe", "finish_name": "pantry", "num_loops":1}}' \
 -H "Content-Type: application/json" 
+
 # Get Task List (GET)
 curl http://localhost:8080/task_list
 ```
@@ -79,7 +80,7 @@ curl http://localhost:8080/task_list
 
 **Submit a list of tasks***
 On the right side column of the web UI, users are able to select a file which consists of a list of  
-tasks. Example. for office world, load `rmf_demos_tasks/rmf_demo_tasks/office_tasks.json`. 
+tasks. Example. for office world, load `rmf_demos_tasks/rmf_demos_tasks/office_tasks.json`. 
 Once the tasks are populated in the box, hit submit!
 
 More details on the format for the `.json` file is presented below.
@@ -93,7 +94,7 @@ For delivery requests:
 ```json
 {"task_type":"Delivery", "start_time":0, "priority":0, "description": {"option": "coke"}}
 ```
-Internally, the option `coke` is mapped to a set of parameters required for a delivery request. This mapping can be seen in the `rmf_dashboard_resources/office/dashboard_config.json` file.
+Internally, the option `coke` is mapped to a set of parameters required for a delivery request. This mapping can be seen in the `rmf_demos_dashboard_resources/office/dashboard_config.json` file.
 
 For clean requests:
 ```json

--- a/rmf_demos_panel/README.md
+++ b/rmf_demos_panel/README.md
@@ -1,20 +1,17 @@
-## RMF Demo Panel Installation
+## RMF Demos Panel
+This will describes more about the details of `rmf_demos_panel`. In short, this package uses a simple web server
+to expose the essential rmf topics/services to the user as web endpoints. Currently, this lite implementation is 
+useful for task submission and observe on-going tasks/robots in RMF.
 
-Setup `rmf_demos_panel`
+### RMF Dependencies
+ - `rmf_task_ros2`
+ - `rmf_fleet_msgs`
+ - `rmf_demos_dashboard_resources`
 
-Rosdep will automatically install system version of python3-flask and python3-flask-cors. Yet we will download flask-socketio (5.x) separately via pip since the ubutuntu packaged version is too old.
+### Setup `rmf_demos_panel`
+
 ```bash
 python3 -m pip install flask-socketio
-```
-
-Compilation
-```bash
-cd ~/rmf_demos_ws
-
-# change the npm prefix according to the path to "rmf_demos_panel/static/"
-npm install --prefix src/rmf/rmf_demos/rmf_demos_panel/rmf_demos_panel/static/
-npm run build --prefix src/rmf/rmf_demos/rmf_demos_panel/rmf_demos_panel/static/
-
 colcon build --packages-select rmf_demos_panel
 ```
 
@@ -30,32 +27,77 @@ Launch the dashboard
 firefox localhost:5000
 ```
 
+> Note that this will download the latest webpack "GUI" hosted on `rmf_demos` github page. Thus internet is
+required when you are running the `gui_server` for the first time.
+
+---
+
+## Development Mode (local)
+
+This development mode is useful for personel who are interested to compile a local React Gui 
+Bundle. **Else you can skip this portion.**.
+
+### Dependencies: 
+ - npm (node version > 12, see: [node](https://nodejs.org/en/download/package-manager/))
+
+### Compilation
+```bash
+cd ~/rmf_ws
+
+# change the npm prefix according to the path to "rmf_demos_panel/static/"
+npm install --prefix src/rmf/rmf_demos/rmf_demos_panel/rmf_demos_panel/static/
+npm run build --prefix src/rmf/rmf_demos/rmf_demos_panel/rmf_demos_panel/static/
+
+colcon build --packages-select rmf_demos_panel
+```
+
+### API Endpoints
+
+Endpoints | Method | body | Description
+--- | --- | --- | ---
+/submit_task | POST | task description json | This supports submission of task
+/cancel_task | POST | task_id string | Cancel a existing task
+/task_list | GET | NULL | Get list of task status in RMF
+/robot_list | GET | NULL | Get list of Robot states in RMF
+/task_status | SocketIO | NULL | Constant broadcast task list
+/robot_states | SocketIO | NULL | Constant broadcast robot list
+
+#### Simple CURL Test on a seperate terminal
+
+```bash
+# Submit Task (POST)
+curl -X POST http://localhost:8080/submit_task \
+-d '{"task_type":"Loop", "start_time":0, "description": {"start_name": "coe", "finish_name": "pantry", "num_loops":1}}' \
+-H "Content-Type: application/json" 
+# Get Task List (GET)
+curl http://localhost:8080/task_list
+```
+
+---
+
 ## Run Sample Tasks
 
-Open `http://localhost:5000/` on browser.
-
-
 **Submit a list of tasks***
-On the right side column, users are able to select a file which consists of a list of  
-tasks. Example. for office world, load `rmf_demos_tasks/rmf_demos_tasks/office_tasks.json`. 
+On the right side column of the web UI, users are able to select a file which consists of a list of  
+tasks. Example. for office world, load `rmf_demos_tasks/rmf_demo_tasks/office_tasks.json`. 
 Once the tasks are populated in the box, hit submit!
 
 More details on the format for the `.json` file is presented below.
 
 For loop requests:
-```
-{"task_type":"Loop", "start_time":0, "description": {"num_loops":5, "start_name":"coe", "finish_name":"lounge"}}
+```json
+{"task_type":"Loop", "start_time":0, "priority":0, "description": {"num_loops":5, "start_name":"coe", "finish_name":"lounge"}}
 ```
 
 For delivery requests:
-```
-{"task_type":"Delivery", "start_time":0, "description": {"option": "coke"}}
+```json
+{"task_type":"Delivery", "start_time":0, "priority":0, "description": {"option": "coke"}}
 ```
 Internally, the option `coke` is mapped to a set of parameters required for a delivery request. This mapping can be seen in the `rmf_dashboard_resources/office/dashboard_config.json` file.
 
 For clean requests:
-```
-{"task_type":"Clean", "start_time":0, "description":{"cleaning_zone":"zone_2"}}
+```json
+{"task_type":"Clean", "start_time":0, "priority":0, "description":{"cleaning_zone":"zone_2"}}
 ```
 
 **Submit a task***
@@ -70,12 +112,21 @@ There are 2 web-based server running behind the scene, namely:
 1. `gui_server` (port `5000`): Providing the static gui to the web client. Non RMF dependent
 2. `api_server` (port `8080`): Hosting all endpoints for gui clients to interact with RMF
 
-To create your own customize GUI, you will only require to create your own `CUSTOM_gui_server` 
-and interact with the existing `api_server`.
+To create your own customize GUI, you will only require to replace the current `gui_server` package with your 
+own custom implementation, while still interact with the existing `api_server`.
+
+---
 
 ## Note
 - Edit the `dashboard_config.json` to configure the input of the Demo World GUI Task Submission.
-The dashboard config file is located here: `rmf_demos_dashboard_resources/$WORLD/dashboard_config.json`.
+The dashboard config file is located here: `rmf_dashboard_resources/$WORLD/dashboard_config.json`.
 - server ip is configurable via `WEB_SERVER_IP_ADDRESS` in the `dashboard.launch.xml`
 - The `api_server` outputs and stores a summarized log: `web_server.log`.
 - cancel task will not be working. A fully functional cancel will be introduced in a future PR.
+- Rosdep will automatically install system version of `python3-flask` and `python3-flask-cors`. Yet we will download `flask-socketio` (5.x) separately via pip since the ubutuntu packaged version is too old.
+- To purely run GUI server (without ros for testing), run :
+  ```bash
+  export DASHBOARD_CONFIG_PATH=src/rmf/rmf_demos/rmf_demos_dashboard_resources/office/dashboard_config.json
+  python src/rmf/rmf_demos/rmf_demos_panel/rmf_demos_panel/gui_server.py
+  # Then, access localhost:5000 on browser
+  ```

--- a/rmf_demos_panel/README.md
+++ b/rmf_demos_panel/README.md
@@ -1,7 +1,7 @@
 ## RMF Demos Panel
-This will describes more about the details of `rmf_demos_panel`. In short, this package uses a simple web server
-to expose the essential rmf topics/services to the user as web endpoints. Currently, this lite implementation is 
-useful for task submission and observe on-going tasks/robots in RMF.
+Here we describe additional details of `rmf_demos_panel`. This package uses a simple web server
+to expose the essential RMF topics/services to users as web endpoints. Currently, this lite implementation is 
+useful for task submission and observing status of on-going tasks and robots in RMF.
 
 ### RMF Dependencies
  - `rmf_task_ros2`
@@ -79,7 +79,7 @@ curl http://localhost:8080/task_list
 ## Run Sample Tasks
 
 **Submit a list of tasks***
-On the right side column of the web UI, users are able to select a file which consists of a list of  
+On the right side column of the panel, users are able to select a file which consists of a list of  
 tasks. Example. for office world, load `rmf_demos_tasks/rmf_demos_tasks/office_tasks.json`. 
 Once the tasks are populated in the box, hit submit!
 
@@ -113,14 +113,14 @@ There are 2 web-based server running behind the scene, namely:
 1. `gui_server` (port `5000`): Providing the static gui to the web client. Non RMF dependent
 2. `api_server` (port `8080`): Hosting all endpoints for gui clients to interact with RMF
 
-To create your own customize GUI, you will only require to replace the current `gui_server` package with your 
-own custom implementation, while still interact with the existing `api_server`.
+To create your own custom GUI, you will only require to replace the current `gui_server` package with your 
+own custom implementation, . The `api_server` remains the same.
 
 ---
 
 ## Note
 - Edit the `dashboard_config.json` to configure the input of the Demo World GUI Task Submission.
-The dashboard config file is located here: `rmf_dashboard_resources/$WORLD/dashboard_config.json`.
+The dashboard config file is located here: `rmf_demos_dashboard_resources/$WORLD/dashboard_config.json`.
 - server ip is configurable via `WEB_SERVER_IP_ADDRESS` in the `dashboard.launch.xml`
 - The `api_server` outputs and stores a summarized log: `web_server.log`.
 - cancel task will not be working. A fully functional cancel will be introduced in a future PR.

--- a/rmf_demos_panel/rmf_demos_panel/gui_server.py
+++ b/rmf_demos_panel/rmf_demos_panel/gui_server.py
@@ -23,7 +23,33 @@ import json
 ###############################################################################
 
 app = Flask(__name__, static_url_path="/static")
-dashboard_config = {"world_name": ""}
+dashboard_config = {"world_name": "EMPTY_DASHBOARD_CONFIG",
+                    "task": {"Delivery": {}, "Loop": {}, "Clean": {}}}
+
+
+# Download bundle from gh page, This will download the webpack bundle if the
+# bundle is not available locally, thus internet is required during download
+def download_webpack():
+    script_dir = os.path.dirname(os.path.realpath(__file__))
+    bundle_path = f"{script_dir}/static/dist/app.bundle.js"
+
+    # source_url is deployed during a push sequence within git page action,
+    # it is advice to update the version (in '.github/workflows/gh_page.yml')
+    # whenever a new feature is introduced
+    source_url = "https://open-rmf.github.io/rmf_demos/v1.0.0/app.bundle.js"
+
+    if os.path.isfile(bundle_path):
+        print("BundleJS File exists, SKIP!")
+    else:
+        print(f"BundleJS File does not exist, Download it from {source_url}")
+        response = requests.get(source_url)
+        if response.status_code == 200:
+            open(bundle_path, 'wb').write(response.content)
+            print(f"Bundle Download completed: {bundle_path}")
+        else:
+            raise UserWarning(f"Failed to download bundle from: {source_url}")
+
+###############################################################################
 
 
 @app.route("/")
@@ -31,6 +57,7 @@ def home():
     return render_template("index.html")
 
 
+# Dashboard Config for each "World"
 @app.route("/dashboard_config", methods=['GET'])
 def config():
     config = jsonify(dashboard_config)
@@ -43,6 +70,8 @@ def main(args=None):
     server_ip = "0.0.0.0"
     port_num = 5000
 
+    download_webpack()
+
     if "WEB_SERVER_IP_ADDRESS" in os.environ:
         server_ip = os.environ['WEB_SERVER_IP_ADDRESS']
         print(f"Set Server IP to: {server_ip}:{port_num}")
@@ -53,8 +82,7 @@ def main(args=None):
         if not config_path:
             print(f"WARN! env DASHBOARD_CONFIG_PATH is empty...")
         elif not os.path.exists(config_path):
-            print(f"File [{config_path}] doesnt exist")
-            raise FileNotFoundError
+            raise FileNotFoundError(f"\n File [{config_path}] doesnt exist")
         else:
             try:
                 f = open(config_path, 'r')

--- a/rmf_demos_panel/rmf_demos_panel/static/package.json
+++ b/rmf_demos_panel/rmf_demos_panel/static/package.json
@@ -8,6 +8,7 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "build": "webpack --progress --config webpack.config.js",
+    "build-dev": "webpack --mode development --progress --config webpack.config.js",
     "dev-build": "webpack --progress --config webpack.config.js",
     "watch": "webpack --progress --config webpack.config.js --watch"
   },

--- a/rmf_demos_panel/rmf_demos_panel/static/webpack.config.js
+++ b/rmf_demos_panel/rmf_demos_panel/static/webpack.config.js
@@ -4,14 +4,15 @@ const resolve = require('path').resolve;
 const config = {
     entry:  {
         app: resolve(__dirname, 'src/index.tsx'),
-        panels: resolve(__dirname, 'src/components/panels-container'),
-        rosClock: resolve(__dirname, 'src/components/fixed-components/rostime-clock'),
-        cleaningForm: resolve(__dirname, 'src/components/forms/cleaning-form'),
-        deliveryForm: resolve(__dirname, 'src/components/forms/delivery-form'),
-        loopRequestForm: resolve(__dirname, 'src/components/forms/loop-request-form'),
-        scheduledTaskForm: resolve(__dirname, 'src/components/forms/scheduled-task-form'),
-        taskContainer: resolve(__dirname, 'src/components/tasks/tasks-container'),
-        robotContainer: resolve(__dirname, 'src/components/robots/robot-cards-container')
+        //// NOTE: these are not necessary
+        // panels: resolve(__dirname, 'src/components/panels-container'),
+        // rosClock: resolve(__dirname, 'src/components/fixed-components/rostime-clock'),
+        // cleaningForm: resolve(__dirname, 'src/components/forms/cleaning-form'),
+        // deliveryForm: resolve(__dirname, 'src/components/forms/delivery-form'),
+        // loopRequestForm: resolve(__dirname, 'src/components/forms/loop-request-form'),
+        // scheduledTaskForm: resolve(__dirname, 'src/components/forms/scheduled-task-form'),
+        // taskContainer: resolve(__dirname, 'src/components/tasks/tasks-container'),
+        // robotContainer: resolve(__dirname, 'src/components/robots/robot-cards-container')
     },
     output: {
       path: resolve(__dirname, './dist'),

--- a/rmf_demos_panel/rmf_demos_panel/templates/index.html
+++ b/rmf_demos_panel/rmf_demos_panel/templates/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" dir="ltr">
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
-<script src="//cdnjs.cloudflare.com/ajax/libs/socket.io/3.0.5/socket.io.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/3.0.5/socket.io.js"></script>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.1/css/all.min.css">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/antd/4.9.4/antd.min.css">
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" />
@@ -13,9 +13,11 @@
 
 <body>
   <div id="root">
-    <p>Loading...</p>
+    <p>Loading... static/dist/app.bundle.js.</p>
+    </p>
   </div>
 <hr>
+
 <script src="../static/dist/app.bundle.js" type="text/javascript"></script>
 </body>
 </html>


### PR DESCRIPTION
Split off from https://github.com/open-rmf/rmf_demos/pull/2. Added 3 CIs:
- style
- build: (full colcon build from starting from https://github.com/open-rmf/rmf)
- Deploy: `rmf_demos_panel` webpack bundle to `gh-page` during merge to `main`.

One useful feature with the new Deploy CI is that it omits the `npm build` setup process for the weppack gui. Internally the webpack bundle will get downloaded by the `gui_server` if it is not available locally. Documentations are also updated accordingly.