### PR TITLE
Update common.launch.xml after changes to rmf_schedule_visualizer

### DIFF
--- a/rmf_demos/launch/common.launch.xml
+++ b/rmf_demos/launch/common.launch.xml
@@ -7,7 +7,7 @@
   <arg name="config_file" description="Building description file required by building_map_tools"/>
   <arg name="dashboard_config_file" default="" description="Path to dashboard config for web rmf panel file"/>
   <arg name="initial_map" default="L1" description="Initial map name for the visualizer"/>
-  <arg name="headless" description="do not launch rviz; launch gazebo in headless mode" default="false"/>
+  <arg name="headless" default="false" description="do not launch rviz; launch gazebo in headless mode"/>
   <arg name="bidding_time_window" description="Time window in seconds for task bidding process" default="2.0"/>
 
   <!-- Traffic Schedule  -->
@@ -28,14 +28,13 @@
   </group>
 
   <!-- Visualizer -->
-  <group unless="$(var headless)">
-    <include file="$(find-pkg-share visualizer)/visualizer.xml">
+  <group>
+    <include file="$(find-pkg-share visualizer)/visualizer.launch.xml">
       <arg name="map_name" value="$(var initial_map)"/>
       <arg name="viz_config_file" value ="$(var viz_config_file)"/>
+      <arg name="headless" value="$(var headless)"/>
     </include>
   </group>
-  <include file="$(find-pkg-share visualizer)/server.xml">
-  </include>
 
   <!-- Door Supervisor -->
   <group>


### PR DESCRIPTION
Signed-off-by: Yadunund <yadunund@openrobotics.org>

<!--
For support requests, please read the Support Guidelines to know where to ask: https://github.com/open-rmf/rmf/wiki/Support-guidelines
For general questions and design discussion, please use the Discussions page: https://github.com/open-rmf/rmf/discussions
Not sure if this is the right repository? Open an issue on https://github.com/open-rmf/rmf
For bug fix pull requests, please fill out the information below.
Be as detailed as possible.
-->

## Bug fix

### Fixed bug
With https://github.com/open-rmf/rmf_visualization/pull/3, the `server.xml` launch file no longer exists in the `visualizer` package. The websocket trajectory server is launched along with the schedule marker publisher in `visualizer.launch.xml`.

<!-- Briefly describe the bug being fixed.
If there is a bug report issue for the bug, link to that issue.
If there is not a bug report issue for the bug, create one first and fill out all the required information there, then link to that issue from this bug fix pull request. -->

### Fix applied
Updated `common.launch.xml` in `rmf_demos`.
