### PR TITLE
account for refactor from building_gazebo_plugins to rmf_building_sim…

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,10 +23,6 @@ jobs:
     - name: create-ws
       run: |
         mkdir -p rmf_demos_ws/src
-    - name: checkout
-      uses: actions/checkout@v2
-      with:
-        path: rmf_demos_ws/src/rmf/rmf_demos
     - name: workspace
       run: |
         cd rmf_demos_ws

--- a/rmf_demos/launch/simulation.launch.xml
+++ b/rmf_demos/launch/simulation.launch.xml
@@ -11,7 +11,7 @@
     <let name="world_path" value="$(find-pkg-share $(var map_package))/maps/$(var map_name)/$(var map_name).world" />
     <let name="model_path" value="$(find-pkg-share $(var map_package))/maps/$(var map_name)/models:$(find-pkg-share rmf_demos_assets)/models:/usr/share/gazebo-$(var gazebo_version)/models" />
     <let name="resource_path" value="$(find-pkg-share rmf_demos_assets):/usr/share/gazebo-$(var gazebo_version)" />
-    <let name="plugin_path" value="$(find-pkg-prefix rmf_robot_sim_gazebo_plugins)/lib:$(find-pkg-prefix building_gazebo_plugins)/lib:/usr/share/gazebo-$(var gazebo_version)" />
+    <let name="plugin_path" value="$(find-pkg-prefix rmf_robot_sim_gazebo_plugins)/lib:$(find-pkg-prefix rmf_building_sim_gazebo_plugins)/lib:/usr/share/gazebo-$(var gazebo_version)" />
 
     <executable cmd="gzserver --verbose -s libgazebo_ros_factory.so -s libgazebo_ros_init.so $(var world_path)" output="both">
       <env name="GAZEBO_MODEL_PATH" value="$(var model_path)" />

--- a/rmf_demos/package.xml
+++ b/rmf_demos/package.xml
@@ -15,7 +15,7 @@
   <exec_depend>rmf_task_ros2</exec_depend>
   <exec_depend>rmf_fleet_adapter</exec_depend>
   <exec_depend>building_map_tools</exec_depend>
-  <exec_depend>building_gazebo_plugins</exec_depend>
+  <exec_depend>rmf_building_sim_gazebo_plugins</exec_depend>
 
   <exec_depend>visualizer</exec_depend>
 

--- a/rmf_demos/sros2/office_deploy.bash
+++ b/rmf_demos/sros2/office_deploy.bash
@@ -84,7 +84,7 @@ sleep 2
 
 echo "export GAZEBO_MODEL_PATH=$WORKSPACE/install/rmf_demos_maps/share/rmf_demos_maps/maps/office/models:$WORKSPACE/install/rmf_demos_assets/share/rmf_demos_assets/models:/usr/share/gazebo-11/models
 export GAZEBO_RESOURCE_PATH=$WORKSPACE/install/rmf_demos_assets/share/rmf_demos_assets:/usr/share/gazebo-11
-export GAZEBO_PLUGIN_PATH=$WORKSPACE/install/rmf_robot_sim_gazebo_plugins/lib:$WORKSPACE/install/building_gazebo_plugins/lib/
+export GAZEBO_PLUGIN_PATH=$WORKSPACE/install/rmf_robot_sim_gazebo_plugins/lib:$WORKSPACE/install/rmf_building_sim_gazebo_plugins/lib/
 export GAZEBO_MODEL_DATABASE_URI=\"\"" > $WORKSPACE/gazebo_environment.bash
 
 tmux send-keys -t 8 "source $WORKSPACE/sros2_environment.bash" Enter

--- a/rmf_demos_assets/package.xml
+++ b/rmf_demos_assets/package.xml
@@ -10,7 +10,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <exec_depend>rmf_robot_sim_gazebo_plugins</exec_depend>
-  <exec_depend>building_gazebo_plugins</exec_depend>
+  <exec_depend>rmf_building_sim_gazebo_plugins</exec_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
Minor refactoring to account for changes from this [refactoring](https://github.com/open-rmf/rmf_traffic_editor/pull/308). Also changed the build script to remove a duplicate rmf_demo workspace from [this change](https://github.com/open-rmf/rmf/blob/main/rmf.repos#L58-L61). 

Will depend on refactors from https://github.com/open-rmf/rmf_visualization/pull/5 and https://github.com/open-rmf/rmf_simulation/pull/3 for clean successful build.

Signed-off-by: Boon Han <charayaphan.nakorn.boon.han@gmail.com>

