### PR TITLE
Update ignition launch for new sim plugin names

### DIFF
--- a/rmf_demos/launch/simulation.launch.xml
+++ b/rmf_demos/launch/simulation.launch.xml
@@ -32,7 +32,7 @@
   <group if="$(var use_ignition)">
     <let name="world_path" value="$(find-pkg-share $(var map_package))/maps/$(var map_name)_ign/$(var map_name).world" />
     <let name="model_path" value="$(find-pkg-share $(var map_package))/maps/$(var map_name)_ign/models:$(find-pkg-share rmf_demos_assets)/models:$(env HOME)/.gazebo/models" />
-    <let name="plugin_path" value="$(find-pkg-prefix rmf_robot_sim_ignition_plugins)/lib:$(find-pkg-prefix building_ignition_plugins)/lib" />
+    <let name="plugin_path" value="$(find-pkg-prefix rmf_robot_sim_ignition_plugins)/lib:$(find-pkg-prefix rmf_building_sim_ignition_plugins)/lib" />
     <executable cmd="ign gazebo -r -v 4 $(var world_path)" output="both">
 
       <env


### PR DESCRIPTION
## Bug fix

### Fixed bug

The package for building plugins was renamed from `building_ignition_plugins` to `rmf_building_sim_ignition_plugins` during the transition and ignition demos failed to launch.

### Fix applied

The package name has been fixed and now ignition plugin launch as intended.