### PR TITLE
Remove outdated traffic editor .project files

### DIFF
--- a/rmf_demos_maps/maps/airport_terminal/airport_terminal.project.yaml
+++ b/rmf_demos_maps/maps/airport_terminal/airport_terminal.project.yaml
@@ -1,6 +1,0 @@
-building:
-  filename: airport_terminal.building.yaml
-name: airport_terminal
-traffic_maps:
-  {}
-version: 1

--- a/rmf_demos_maps/maps/battle_royale/battle_royale.project.yaml
+++ b/rmf_demos_maps/maps/battle_royale/battle_royale.project.yaml
@@ -1,6 +1,0 @@
-building:
-  filename: battle_royale.building.yaml
-name: battle_royale
-traffic_maps:
-  {}
-version: 1

--- a/rmf_demos_maps/maps/clinic/clinic.project.yaml
+++ b/rmf_demos_maps/maps/clinic/clinic.project.yaml
@@ -1,6 +1,0 @@
-building:
-  filename: clinic.building.yaml
-name: clinic
-traffic_maps:
-  {}
-version: 1

--- a/rmf_demos_maps/maps/hotel/hotel.project.yaml
+++ b/rmf_demos_maps/maps/hotel/hotel.project.yaml
@@ -1,6 +1,0 @@
-building:
-  filename: hotel.building.yaml
-name: hotel
-traffic_maps:
-  {}
-version: 1

--- a/rmf_demos_maps/maps/hotel_full/hotel_full.project.yaml
+++ b/rmf_demos_maps/maps/hotel_full/hotel_full.project.yaml
@@ -1,6 +1,0 @@
-building:
-  filename: hotel_full.building.yaml
-name: hotel_full
-traffic_maps:
-  {}
-version: 1

--- a/rmf_demos_maps/maps/office/office.project.yaml
+++ b/rmf_demos_maps/maps/office/office.project.yaml
@@ -1,6 +1,0 @@
-building:
-  filename: office.building.yaml
-name: office
-traffic_maps:
-  {}
-version: 1

--- a/rmf_demos_maps/maps/triple_H/triple_H.project.yaml
+++ b/rmf_demos_maps/maps/triple_H/triple_H.project.yaml
@@ -1,6 +1,0 @@
-building:
-  filename: triple_H.building.yaml
-name: triple_H
-traffic_maps:
-  {}
-version: 1


### PR DESCRIPTION
## Bug fix

### Fixed bug

`.project` files for traffic_editor maps are not used anymore since the refactoring took place in [traffic_editor's #301](https://github.com/open-rmf/rmf_traffic_editor/pull/301). When opening them with traffic_editor a warning is printed and the project failes to load, `.building` files should be used instead.

### Fix applied

This PR removes the deprecated files.