### PR TITLE
Fix readme media

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The Robotics Middleware Framework (RMF) enables interoperability among heterogen
 
 This repository contains demonstrations of the above mentioned capabilities of RMF. It serves as a starting point for working and integrating with RMF.
 
-[<img src="http://drive.google.com/uc?export=view&id=16Qow_k0ozzcfpSij73tTffnSFtNduLvR" alt="thumbnail.png">](https://vimeo.com/405803151)
+[![Robotics Middleware Framework](../media/thumbnail.png?raw=true)](https://vimeo.com/405803151)
 
 #### (Click to watch video)
 
@@ -32,7 +32,7 @@ Answers to frequently asked questions can be found [here](docs/faq.md).
 A near-term roadmap of the RMF project can be found in the user manual [here](https://osrf.github.io/ros2multirobotbook/roadmap.html).
 
 ## RMF Panel
-<img src="http://drive.google.com/uc?export=view&id=18VXRwsuoE5bAXHzGQI3PCRyqFGdmJvY7" alt="RMF_Panel.png">
+![](../media/RMF_Panel.png?raw=true)
 
 The RMF panel is a web based dashboard for interacting with RMF. It allows users to send task requests to RMF and monitor the status of robots and submitted tasks.
 There are two main modes of submitting tasks to RMF via the Panel:
@@ -76,12 +76,12 @@ ros2 run rmf_demos_tasks dispatch_loop -s coe -f lounge -n 3 --use_sim_time
 ros2 run rmf_demos_tasks dispatch_delivery -p pantry -pd coke_dispenser -d hardware_2 -di coke_ingestor --use_sim_time
 ```
 
-<img src="http://drive.google.com/uc?export=view&id=12Ojwb2qmUKZnpnlMyzpoQPywAKOmlccW" alt="delivery_request.gif">
+![](../media/delivery_request.gif?raw=true)
 
 To send loop requests, select `Loop` from the `Select a request type` dropdown list. Choose desired start and end locations and click submit.
 To run a scenario with multiple task requests, load `office_tasks.json` from `rmf_demos_panel/task_lists` in the `Submit a list of tasks` section. This should populate the preview window with a list of tasks. Click submit and watch the demonstration unfold.
 
-<img src="http://drive.google.com/uc?export=view&id=1dYqHvSdl4wNN3Gk2-jPPM4SjfXs1d41N" alt="loop_request.gif">
+![](../media/loop_request.gif)
 
 The office demo can be run in secure mode using ROS 2 DDS-Security integration. Click [here](docs/secure_office_world.md) to learn more.
 
@@ -91,8 +91,8 @@ The office demo can be run in secure mode using ROS 2 DDS-Security integration. 
 
 This demo world shows robot interaction on a much larger map, with a lot more lanes, destinations, robots and possible interactions between robots from different fleets, robots and infrastructure, as well as robots and users. In the illustrations below, from top to bottom we have how the world looks like in `traffic_editor`, the schedule visualizer in `rviz`, and the full simulation in `gazebo`,
 
-<img src="http://drive.google.com/uc?export=view&id=13rlqpBw4Z22XClLKaVPKZ87szQ1emEnD" alt="airport_terminal_traffic_editor_screenshot.png">
-<img src="http://drive.google.com/uc?export=view&id=17demXDdp1V_HxTH3LRwdCm39MFmJ4KH6" alt="airport_terminal_demo_screenshot.png">
+![](../media/airport_terminal_traffic_editor_screenshot.png)
+![](../media/airport_terminal_demo_screenshot.png)
 
 #### Demo Scenario
 To launch the world and the schedule visualizer,
@@ -115,7 +115,7 @@ Non-autonomous vehicles can also be integrated with RMF provided their positions
 
 In the airport terminal map, a `Caddy` is spawned in the far right corner and can be controlled with `geometry_msgs/Twist` messages published over the `cmd_vel` topic. 
 
-<img src="http://drive.google.com/uc?export=view&id=1zbbzRv8bWdIj6JboZj_mf8ntsGhl9ojG" alt="caddy.gif">
+![](../media/caddy.gif)
 
 ---
 
@@ -123,7 +123,7 @@ In the airport terminal map, a `Caddy` is spawned in the far right corner and ca
 
 This is a clinic world with two levels and two lifts for the robots. Two different robot fleets with different roles navigate across two levels by lifts. In the illustrations below, we have the view of level 1 in `traffic_editor` (top left), the schedule visualizer in `rviz` (right), and the full simulation in `gazebo` (bottom left).
 
-<img src="http://drive.google.com/uc?export=view&id=164T1HorZfnKdmrQN-H0UF3KvLRFdiNko" alt="clinic.png">
+![](../media/clinic.png)
 
 #### Demo Scenario
 To launch the world and the schedule visualizer,
@@ -143,12 +143,12 @@ ros2 run rmf_demos_tasks dispatch_loop -s L2_north_counter -f L1_right_nurse_cen
 
 Robots taking lift:
 
-<img src="http://drive.google.com/uc?export=view&id=11zfxGgckrCefXFYOu1CMk27Yiz3PiUiF" alt="robot_taking_lift.gif">
+![](../media/robot_taking_lift.gif)
 
 
 Multi-fleet demo:
 
-<img src="http://drive.google.com/uc?export=view&id=1ic_-YQI9-tjJY8hVu1VmR_mRzPFzhqZ1" alt="clinic.gif">
+![](../media/clinic.gif)
 
 ---
 
@@ -159,10 +159,10 @@ This is a hotel with a lobby and a guest level. The hotel has two lifts and two 
 The hotel map is truncated due to the high memory usage. The full map can be accessed [here](https://github.com/MakinoharaShouko/hotel).
 
 Hotel floor plan in `traffic_editor`:
-<img src="http://drive.google.com/uc?export=view&id=11zfxGgckrCefXFYOu1CMk27Yiz3PiUiF" alt="hotel.png">
+![](../media/hotel.png)
 
 Full hotel floor plan in `traffic_editor`:
-<img src="http://drive.google.com/uc?export=view&id=1OVO781oFlrTnDhuH0xFK_fWfZ0Oavi74" alt="hotel_full.png">
+![](../media/hotel_full.png)
 
 #### Demo Scenario
 
@@ -177,7 +177,7 @@ Select the `hotel` tab on RMF Panel. Loop requests can be submitted via "Submit 
 
 Robot taking lift:
 
-<img src="http://drive.google.com/uc?export=view&id=11zfxGgckrCefXFYOu1CMk27Yiz3PiUiF" alt="robot_taking_lift_hotel.gif">
+![](../media/robot_taking_lift_hotel.gif)
 
 ---
 
@@ -205,7 +205,7 @@ $ ros2 launch rmf_demos office_mock_traffic_light.launch.xml
 ```
 
 ## Task Dispatching in RMF
-<img src="http://drive.google.com/uc?export=view&id=1rIyfhvQwzKUK-O3eoHUlvoIqahnB5GzT" alt="RMF_Bidding.png">
+![](../media/RMF_Bidding.png)
 
 In RMF version `21.04` and above, tasks are awarded to robot fleets based on the outcome of a bidding process that is orchestrated by a Dispatcher node, `rmf_dispatcher_node`. When the Dispatcher receives a new task request from a UI, it sends out a `rmf_task_msgs/BidNotice` message to all the fleet adapters. If a fleet adapter is able to process that request, it submits a `rmf_task_msgs/BidProposal` message back to the Dispatcher with a cost to accommodate the task. An instance of `rmf_task::agv::TaskPlanner` is used by the fleet adapters to determine how best to accommodate the new request. The Dispatcher compares all the `BidProposals` received and then submits a `rmf_task_msgs/DispatchRequest` message with the fleet name of the robot that the bid is awarded to. There are a couple different ways the Dispatcher evaluates the proposals such as fastest to finish, lowest cost, etc which can be configured.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ These demos were developed and tested on
 * [Gazebo 11.1.0](http://gazebosim.org/)
 
 ## Installation
-Instructions can be found [here](docs/installation.md).
+Instructions can be found [here](https://github.com/open-rmf/rmf).
 
 ## FAQ
 Answers to frequently asked questions can be found [here](docs/faq.md).

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The Robotics Middleware Framework (RMF) enables interoperability among heterogen
 
 This repository contains demonstrations of the above mentioned capabilities of RMF. It serves as a starting point for working and integrating with RMF.
 
-[![Robotics Middleware Framework](docs/media/thumbnail.png)](https://vimeo.com/405803151)
+[<img src="http://drive.google.com/uc?export=view&id=16Qow_k0ozzcfpSij73tTffnSFtNduLvR" alt="thumbnail.png">](https://vimeo.com/405803151)
 
 #### (Click to watch video)
 
@@ -32,7 +32,7 @@ Answers to frequently asked questions can be found [here](docs/faq.md).
 A near-term roadmap of the RMF project can be found in the user manual [here](https://osrf.github.io/ros2multirobotbook/roadmap.html).
 
 ## RMF Panel
-![](docs/media/RMF_Panel.png)
+<img src="http://drive.google.com/uc?export=view&id=18VXRwsuoE5bAXHzGQI3PCRyqFGdmJvY7" alt="RMF_Panel.png">
 
 The RMF panel is a web based dashboard for interacting with RMF. It allows users to send task requests to RMF and monitor the status of robots and submitted tasks.
 There are two main modes of submitting tasks to RMF via the Panel:
@@ -76,12 +76,12 @@ ros2 run rmf_demos_tasks dispatch_loop -s coe -f lounge -n 3 --use_sim_time
 ros2 run rmf_demos_tasks dispatch_delivery -p pantry -pd coke_dispenser -d hardware_2 -di coke_ingestor --use_sim_time
 ```
 
-![](docs/media/delivery_request.gif)
+<img src="http://drive.google.com/uc?export=view&id=12Ojwb2qmUKZnpnlMyzpoQPywAKOmlccW" alt="delivery_request.gif">
 
 To send loop requests, select `Loop` from the `Select a request type` dropdown list. Choose desired start and end locations and click submit.
 To run a scenario with multiple task requests, load `office_tasks.json` from `rmf_demos_panel/task_lists` in the `Submit a list of tasks` section. This should populate the preview window with a list of tasks. Click submit and watch the demonstration unfold.
 
-![](docs/media/loop_request.gif)
+<img src="http://drive.google.com/uc?export=view&id=1dYqHvSdl4wNN3Gk2-jPPM4SjfXs1d41N" alt="loop_request.gif">
 
 The office demo can be run in secure mode using ROS 2 DDS-Security integration. Click [here](docs/secure_office_world.md) to learn more.
 
@@ -91,8 +91,8 @@ The office demo can be run in secure mode using ROS 2 DDS-Security integration. 
 
 This demo world shows robot interaction on a much larger map, with a lot more lanes, destinations, robots and possible interactions between robots from different fleets, robots and infrastructure, as well as robots and users. In the illustrations below, from top to bottom we have how the world looks like in `traffic_editor`, the schedule visualizer in `rviz`, and the full simulation in `gazebo`,
 
-![](docs/media/airport_terminal_traffic_editor_screenshot.png)
-![](docs/media/airport_terminal_demo_screenshot.png)
+<img src="http://drive.google.com/uc?export=view&id=13rlqpBw4Z22XClLKaVPKZ87szQ1emEnD" alt="airport_terminal_traffic_editor_screenshot.png">
+<img src="http://drive.google.com/uc?export=view&id=17demXDdp1V_HxTH3LRwdCm39MFmJ4KH6" alt="airport_terminal_demo_screenshot.png">
 
 #### Demo Scenario
 To launch the world and the schedule visualizer,
@@ -115,7 +115,7 @@ Non-autonomous vehicles can also be integrated with RMF provided their positions
 
 In the airport terminal map, a `Caddy` is spawned in the far right corner and can be controlled with `geometry_msgs/Twist` messages published over the `cmd_vel` topic. 
 
-![](docs/media/caddy.gif)
+<img src="http://drive.google.com/uc?export=view&id=1zbbzRv8bWdIj6JboZj_mf8ntsGhl9ojG" alt="caddy.gif">
 
 ---
 
@@ -123,7 +123,7 @@ In the airport terminal map, a `Caddy` is spawned in the far right corner and ca
 
 This is a clinic world with two levels and two lifts for the robots. Two different robot fleets with different roles navigate across two levels by lifts. In the illustrations below, we have the view of level 1 in `traffic_editor` (top left), the schedule visualizer in `rviz` (right), and the full simulation in `gazebo` (bottom left).
 
-![](docs/media/clinic.png)
+<img src="http://drive.google.com/uc?export=view&id=164T1HorZfnKdmrQN-H0UF3KvLRFdiNko" alt="clinic.png">
 
 #### Demo Scenario
 To launch the world and the schedule visualizer,
@@ -143,11 +143,12 @@ ros2 run rmf_demos_tasks dispatch_loop -s L2_north_counter -f L1_right_nurse_cen
 
 Robots taking lift:
 
-![](docs/media/robot_taking_lift.gif)
+<img src="http://drive.google.com/uc?export=view&id=11zfxGgckrCefXFYOu1CMk27Yiz3PiUiF" alt="robot_taking_lift.gif">
+
 
 Multi-fleet demo:
 
-![](docs/media/clinic.gif)
+<img src="http://drive.google.com/uc?export=view&id=1ic_-YQI9-tjJY8hVu1VmR_mRzPFzhqZ1" alt="clinic.gif">
 
 ---
 
@@ -158,10 +159,10 @@ This is a hotel with a lobby and a guest level. The hotel has two lifts and two 
 The hotel map is truncated due to the high memory usage. The full map can be accessed [here](https://github.com/MakinoharaShouko/hotel).
 
 Hotel floor plan in `traffic_editor`:
-![](docs/media/hotel.png)
+<img src="http://drive.google.com/uc?export=view&id=11zfxGgckrCefXFYOu1CMk27Yiz3PiUiF" alt="hotel.png">
 
 Full hotel floor plan in `traffic_editor`:
-![](docs/media/hotel_full.png)
+<img src="http://drive.google.com/uc?export=view&id=1OVO781oFlrTnDhuH0xFK_fWfZ0Oavi74" alt="hotel_full.png">
 
 #### Demo Scenario
 
@@ -176,7 +177,7 @@ Select the `hotel` tab on RMF Panel. Loop requests can be submitted via "Submit 
 
 Robot taking lift:
 
-![](docs/media/robot_taking_lift_hotel.gif)
+<img src="http://drive.google.com/uc?export=view&id=11zfxGgckrCefXFYOu1CMk27Yiz3PiUiF" alt="robot_taking_lift_hotel.gif">
 
 ---
 
@@ -204,7 +205,7 @@ $ ros2 launch rmf_demos office_mock_traffic_light.launch.xml
 ```
 
 ## Task Dispatching in RMF
-![](docs/media/RMF_Bidding.png)
+<img src="http://drive.google.com/uc?export=view&id=1rIyfhvQwzKUK-O3eoHUlvoIqahnB5GzT" alt="RMF_Bidding.png">
 
 In RMF version `21.04` and above, tasks are awarded to robot fleets based on the outcome of a bidding process that is orchestrated by a Dispatcher node, `rmf_dispatcher_node`. When the Dispatcher receives a new task request from a UI, it sends out a `rmf_task_msgs/BidNotice` message to all the fleet adapters. If a fleet adapter is able to process that request, it submits a `rmf_task_msgs/BidProposal` message back to the Dispatcher with a cost to accommodate the task. An instance of `rmf_task::agv::TaskPlanner` is used by the fleet adapters to determine how best to accommodate the new request. The Dispatcher compares all the `BidProposals` received and then submits a `rmf_task_msgs/DispatchRequest` message with the fleet name of the robot that the bid is awarded to. There are a couple different ways the Dispatcher evaluates the proposals such as fastest to finish, lowest cost, etc which can be configured.
 

--- a/docker/rmf_entrypoint.bash
+++ b/docker/rmf_entrypoint.bash
@@ -1,5 +1,0 @@
-#!/bin/bash
-set -e
-
-source "/opt/rmf/setup.bash"
-exec "$@"

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,61 @@
+# Frequently Asked Questions
+
+Greetings,
+
+This page aims to document frequently asked questions pertaining to the demonstrations of the Robotics Middleware Framework (also termed RoMi-H) as showcased in this repository. The `rmf_core` repository has an additional [FAQ page](https://github.com/open-rmf/rmf_ros2/blob/master/docs/faq.md) which addresses some important higher level topics.
+
+
+#### Gazebo crashes with `No namespace found` error at launch
+
+This error is known to arise when launching a demo with `Gazebo 9.0.0`. This is the default version that is come with the bionic release of Ubuntu. The demos however require `Gazebo 9.12.0` or `Gazebo 9.13.0`. To update from `Gazebo 9.0.0`, first make sure your package source is up to date.
+
+```
+sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list
+wget https://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
+```
+Then run
+```
+sudo apt-get update
+sudo apt-get upgrade
+```
+
+
+#### Gazebo fails to load several models when launching the Airport Terminal world
+
+The Airport Terminal world is populated with several models that are hosted [here](https://github.com/osrf/gazebo_models) and hence not included in `rmf_demo_assets` to avoid maintaining duplicates. Individual model folders may be downloaded into `~/.gazebo/models/` or the entire collection with the commands below.
+
+```bash
+cd ~/.
+git clone https://github.com/osrf/gazebo_models
+cd gazebo_models
+cp -r ./* ~/.gazebo/models/.
+```
+Now when the demo is re-launched, Gazebo will be able to find the required models.
+
+
+#### Add/Modify models in the Gazebo World
+The position and orientation of models is defined using the `traffic_editor`. Load the desired `.project.yaml` file into `traffic_editor` to add or modify models into the floor plan.
+
+
+#### Running the simulation with Ignition
+Work on supporting the simulations in Ignition is underway. The setup instructions will be updated in the near future. 
+
+
+#### Does RMF work with robots running navigation stacks? The robots in the demo only travel in straight line segments.
+
+Yes. RMF works independent of the technique used by the robot to localize itself and navigate through coordinates in a map. This is because RMF deals with planning at a higher, traffic level which considers the presence of other robot fleets in the same space. RMF maintains a `schedule database` of the intended paths all robots operating in the same environment and monitors the same for potential conflicts that may arise. The costmap is not an occupancy grid of sensor-detected obstacles but rather a database of spaciotemporal representation of robot trajectories. These trajectories are interpolated as cubic splines and account for the respective robot's kinematics.
+
+A trajectory is submitted to the `schedule database` by an `rmf_fleet_adapter` which interfaces with the proprietary `fleet manager` or robot API. The `rmf_fleet adapters` are configurable depending on the level of control offered by the vendor robot fleet. In general a `rmf_fleet_adapter` keeps track of the trajectories of its robots and computes new plans, when a conflict is detected, by entering into a negotiation with the conflicting robot's `rmf_fleet_adapter`. This is possible as each `rmf_fleet_adapter` maintains a mirror of the `schedule database` and hence is aware all the trajectories active in the space. The generated plan may ask the robot to wait at a node or reroute itself along other lanes in the graph. The result of the plan is communicated to the robot's `fleet manager` via a `PathRequest` message. The expectation is that the vendor `fleet manager` will comply to the incoming request and command the respective robot to reach follow the waypoints in the `PathRequest` message to reach its destination, conflict free. Here the robot will make use of its navigation stack and drivers to drive to each of the waypoints while avoiding sensor-detected obstacles. In the meanwhile, the `rmf_fleet_adapter` expects the `fleet manager` to update the current position of the robot and its remaining path back to it via a `RobotState` message. Then for example, if a robot pauses due to a dynamic obstacle in its path, the information is implicitly conveyed via the `RobotState` message and this delay is submitted to the `schedule database` which is now visible to the other `rmf_fleet_adapters`, and can inturn replan their robot routes if affected by the delay.
+
+To replicate this interaction between `rmf_fleet_adapters` and vendor robots in simulation, we have the `slotcar` plugin. This plugin does two things 1) Interface with an `rmf_fleet_adapter` via the described messages and 2) Navigate the robot to the requested waypoint by actuating the model joints. For the later, it implements a simple "rail-like" navigation which accelerates and decelerates the robot along a straight line from its current position to the waypoint. We assume that the robot lanes are free of other static obstacles. This is implemented to minimize computational load on systems running the demos which tends to become very significant when running a ROS1/2 navstack for every robot in the simulation. Since the focus here is on traffic management of heterogeneous fleets and not robot navigation, the `slotcar` plugins allow us to efficiently test various scenarios in simulation.
+
+However, it certainly possible to run the demos with robots powered by navstacks. This would require running a separate node which does 1) Send and receive `RobotState` and `PathRequest` messages resp. as did the `slotcar` and 2) Send goals to the navstack's action server corresponding to the waypoints received in the `PathRequest` message and update the robot's state along the way. Transformations (rotation, translation or scaling) if necessary may be applied to the goal coordinates to account for any variations between the onboard `.pgm` map and the floor plan annotated by the `traffic_editor`. These can be checked for by importing the `.pgm` file into `traffic_editor`.
+This is what we do when we test RMF on physical robots.
+
+
+#### How does RMF detect conflicts and replan routes for mobile robots?
+Kindly refer to the [FAQ](https://github.com/open-rmf/rmf_ros2/blob/master/docs/faq.md#how-does-rmf_traffic-avoid-mobile-robot-traffic-conflicts) in `rmf_core`
+
+
+#### Has RMF been tested with physical robots?
+Yes, RMF has been tested with multiple brands of robots (ROS and non-ROS based) operating in the same space together. Among these robots, two variants offer `full control` integration while the other, `read_only`. More information on integration will be documented in the near future.

--- a/docs/ignition.md
+++ b/docs/ignition.md
@@ -1,0 +1,59 @@
+Note, ROS2 Foxy on Ubuntu 20.04 with Ignition Dome is the only supported setup.
+
+1. Start by setting up your system dependencies:
+
+    ```
+    sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list'
+    wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
+    sudo apt-get update
+    
+    sudo apt install git python3-pip
+    
+    pip3 install vcstool
+    pip3 install -U colcon-common-extensions
+    ```
+
+# Binary installation
+
+The easiest way to setup ignition is to install from binaries:
+
+    ```
+    sudo apt install ignition-dome
+    ```
+
+Alternatively you can install it from source.
+
+# Source installation
+
+1. Install `ignition-dome` from source. The branches in the official guide can be used
+
+    ```
+    mkdir ws_dome/src -p
+    cd ws_dome
+    ```
+
+1. Use the provided `ign-dome.yaml` file and initialise the sources:
+
+    ```
+    wget https://raw.githubusercontent.com/ignition-tooling/gazebodistro/master/collection-dome.yaml
+    vcs import src < collection-dome.yaml
+
+    ```
+
+1. Build from source and source in your .bashrc (or remember to source manually before running any demo):
+
+    ```
+    sudo apt-get install cmake freeglut3-dev libavcodec-dev libavdevice-dev libavformat-dev libavutil-dev libdart6-collision-ode-dev libdart6-dev libdart6-utils-urdf-dev libfreeimage-dev libgflags-dev libglew-dev libgts-dev libogre-1.9-dev libogre-2.1-dev libprotobuf-dev libprotobuf-dev libprotoc-dev libqt5core5a libswscale-dev libtinyxml2-dev libtinyxml-dev pkg-config protobuf-compiler python qml-module-qt-labs-folderlistmodel qml-module-qt-labs-settings qml-module-qtquick2 qml-module-qtquick-controls qml-module-qtquick-controls2 qml-module-qtquick-dialogs qml-module-qtquick-layouts qml-module-qtqml-models2 qtbase5-dev qtdeclarative5-dev qtquickcontrols2-5-dev ruby ruby-ronn uuid-dev libzip-dev libjsoncpp-dev libcurl4-openssl-dev libyaml-dev libzmq3-dev libsqlite3-dev libwebsockets-dev swig ruby-dev -y
+    
+    colcon build --merge-install --symlink-install --cmake-args -DBUILD_TESTING=false
+    
+    echo "source ~/ws_dome/install/setup.bash" >> ~/.bashrc
+    ```
+    
+# Launch
+
+To launch a demo in ignition set the `use_ignition` parameter to 1, i.e. to launch the office demo:
+
+  ```
+  ros2 launch demos office.launch.xml use_ignition:=1
+  ```

--- a/docs/secure_office_world.md
+++ b/docs/secure_office_world.md
@@ -1,0 +1,107 @@
+#### Secure ROS 2 Office Demo
+
+The office demo can be run in secure mode using the [ROS 2 DDS-Security integration](https://design.ros2.org/articles/ros2_dds_security.html) (SROS2) capabilities. This security features will provide encryption, authentication and access control to the whole ROS2 setup of RMF.
+
+Because of the heavy development undergoing RMF, changes happen in a very fast manner. Therefore, the ROS 2 Access Control Policies declared in the `office.policy.xml` file are only guaranteed to work with the RMF release 1.1.X, so please set all the git repos of your RMF workspace to point to the tag `1.1.0`. Alternatively you could update the policies yourself to any later version of RMF (PRs are welcome if you do so :smirk:).
+
+There is a `tmux` based script that automates pane splitting and the execution of all the required commands to run the office demo. In order to run it this way just open a tmux terminal and run the script.
+
+```
+bash ./install/rmf_demos/share/rmf_demos/sros2/office_deploy.bash
+```
+
+Alongside, the following steps can be used to run all required commands individually.
+
+To use ROS 2 to secure the office demo a few environmental variables need to be set. Adding them to a script would make it easier to source them in any shell where we need to run ROS 2 secured nodes.
+
+```bash
+echo 'export ROS_SECURITY_KEYSTORE=~/rmf_demos_ws/keystore
+export ROS_SECURITY_ENABLE=true
+export ROS_SECURITY_STRATEGY=Enforce
+export ROS_DOMAIN_ID=42' > sros2_environment.sh
+```
+
+A few security artifacts like signed permission files, identity certificates and Certificate Authorities (CA) are needed to enable the DDS Security. They can be generated using the security tools from the ROS2 cli. Because of [#242](https://github.com/ros2/sros2/issues/242) and until its solution [#238](https://github.com/ros2/sros2/pull/238) is released it is recommended to generate the security artifacts before switching to `cyclone_dds`.
+
+```
+source sros2_environment.sh
+mkdir keystore
+ros2 security generate_artifacts -k keystore -p ./install/rmf_demos/share/rmf_demos/sros2/policies/office.policy.xml
+```
+
+It is recommended to use `cyclone dds` with the secure version of the demo, make sure it is properly installed, with security support and selected through the correspondent environment variable ([here](https://index.ros.org/doc/ros2/Installation/DDS-Implementations/Working-with-Eclipse-CycloneDDS/) you can find instructions on how to do it). Adding this to the environment script makes it easier to source in any terminal that might need it,
+
+```bash
+echo 'export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp' >> sros2_environment.sh
+```
+
+Because SROS2 does not support `ros2 launch` yet all the different nodes will have to be launched individually. A `yaml` file with the parameters of all the nodes is provided. One terminal per execution is recommended for an easier debug of the system. Make sure you `source ~/rmf_demos_ws/install/setup.bash` in each of them before executing the different commands.
+
+```bash
+source sros2_environment.sh
+ros2 run rmf_traffic_ros2 rmf_traffic_schedule --ros-args --params-file ./install/rmf_demos/share/rmf_demos/sros2/office.params.yaml --enclave /office/rmf_traffic_schedule_node
+```
+
+```bash
+source sros2_environment.sh
+ros2 run rmf_building_map_tools building_map_server ./install/rmf_demos_maps/share/rmf_demos_maps/office/office.building.yaml --ros-args --enclave /office/building_map_server
+```
+
+```bash
+source sros2_environment.sh
+ros2 run rmf_schedule_visualizer rviz2 -r 10 -m L1 --ros-args --params-file ./install/rmf_demos/share/rmf_demos/sros2/office.params.yaml --enclave /office/rviz2_node
+```
+
+```bash
+source sros2_environment.sh
+ros2 run building_systems_visualizer building_systems_visualizer -m L1 --ros-args --params-file ./install/rmf_demos/share/rmf_demos/sros2/office.params.yaml --enclave /office/building_systems_visualizer
+```
+
+```bash
+source sros2_environment.sh
+ros2 run fleet_state_visualizer fleet_state_visualizer -m L1 --ros-args --params-file ./install/rmf_demos/share/rmf_demos/sros2/office.params.yaml --enclave /office/fleet_state_visualizer
+```
+
+```bash
+source sros2_environment.sh
+rviz2 -d ./install/rmf_demos/share/rmf_demos/include/office/office.rviz --ros-args --enclave /office/rviz2
+```
+
+```bash
+source sros2_environment.sh
+ros2 run rmf_fleet_adapter door_supervisor --ros-args --enclave /office/door_supervisor
+```
+
+Gazebo needs the environment variables to locate files, and set up communications between the server and clients. They can be added to a script for an easier re-use.
+
+```bash
+echo 'export GAZEBO_MODEL_PATH=~/rmf_demos_ws/install/rmf_demos_maps/share/rmf_demos_maps/maps/office/models:~/rmf_demos_ws/install/rmf_demos_assets/share/rmf_demos_assets/models:/usr/share/gazebo-11/models
+export GAZEBO_RESOURCE_PATH=~/rmf_demos_ws/install/rmf_demos_assets/share/rmf_demos_assets:/usr/share/gazebo-11
+export GAZEBO_PLUGIN_PATH=~/rmf_demos_ws/install/rmf_robot_sim_gazebo_plugins/lib:~/rmf_demos_ws/install/building_gazebo_plugins/lib/
+export GAZEBO_MODEL_DATABASE_URI=""' > gazebo_environment.sh
+```
+
+```bash
+source sros2_environment.sh
+source gazebo_environment.sh
+gzserver --verbose -s libgazebo_ros_factory.so -s libgazebo_ros_init.so ./install/rmf_demos_maps/share/rmf_demos_maps/maps/office/office.world --ros-args --enclave /office/gzserver
+```
+
+Because of [#151](https://github.com/osrf/rmf_rmf_demos/issues/151), the ros node created by plugins run on gzclient will be left out of the secured network. This should only affect the `toggle_floors` plugin that runs on gzclient and is intended for multilevel demos.
+
+```bash
+source gazebo_environment.sh
+gzclient --verbose ./install/rmf_demos_maps/share/rmf_demos_maps/maps/office/office.world
+```
+
+```bash
+source sros2_environment.sh
+ros2 run rmf_fleet_adapter full_control --ros-args -r __node:=tinyRobot_fleet_adapter --params-file ./install/rmf_demos/share/rmf_demos/sros2/office.params.yaml --enclave /office/tinyRobot_fleet_adapter
+```
+
+```bash
+source sros2_environment.sh
+ros2 run rmf_fleet_adapter robot_state_aggregator --ros-args -r __node:=tinyRobot_state_aggregator --params-file ./install/rmf_demos/share/rmf_demos/sros2/office.params.yaml --enclave /office/tinyRobot_state_aggregator
+```
+
+The system is now ready to attend simulated delivery requests as per usual but with all the guarantees of [DDS-security](https://www.omg.org/spec/DDS-SECURITY/1.1/PDF)!


### PR DESCRIPTION
Re-add the missing media files and docs in `README.md`. https://github.com/open-rmf/rmf_demos/issues/12

In order to keep the trim down the usage of media files, without using up space in the git history, we will strore all media files in a `media` [branch](https://github.com/open-rmf/rmf_demos/tree/media). This media branch will be treated as a static file hosting site. Thus whenver new media files are uploaded, we will forcefully clean all history in `media` branch.

Extra Note: Tested the gdrive method https://github.com/open-rmf/rmf_demos/commit/5a4c46016d5943e4b8433bc9c4c0d79eadabb659, wasnt ideal as the cdn links tend to be unstable (weirdly)
