### PR TITLE
Fix out of range values for sdf compliance

### DIFF
--- a/rmf_demos_assets/models/TeleportDispenser/model.sdf
+++ b/rmf_demos_assets/models/TeleportDispenser/model.sdf
@@ -14,8 +14,8 @@
           </box>
         </geometry>
         <material>
-          <ambient>128 192 210 0.1</ambient>
-          <diffuse>128 192 210 0.1</diffuse>
+          <ambient>0.8 0.8 0.8 0.1</ambient>
+          <diffuse>0.8 0.8 0.8 0.1</diffuse>
         </material>
       </visual>
     </link>

--- a/rmf_demos_assets/models/TeleportIngestor/model.sdf
+++ b/rmf_demos_assets/models/TeleportIngestor/model.sdf
@@ -14,8 +14,8 @@
           </box>
         </geometry>
         <material>
-          <ambient>128 192 210 0.1</ambient>
-          <diffuse>128 192 210 0.1</diffuse>
+          <ambient>0.8 0.8 0.8 0.1</ambient>
+          <diffuse>0.8 0.8 0.8 0.1</diffuse>
         </material>
       </visual>
     </link>


### PR DESCRIPTION
## Bug fix

### Fixed bug

The values for TeleportDispenser and TeleportIngestor `ambient` and `diffuse` are outside of the [0.0 - 1.0] range which is [against the specification](http://sdformat.org/spec?ver=1.7&elem=material#material_ambient) and causes runtime errors since sdformat11.

### Fix applied

Changed the colors to a neutral grey in the range of [0.0 - 1.0]