### PR TITLE
fix caddy discover timeout

### DIFF
--- a/rmf_demos/launch/include/adapters/caddy_adapter.launch.xml
+++ b/rmf_demos/launch/include/adapters/caddy_adapter.launch.xml
@@ -24,6 +24,9 @@
       <!-- Other robots are not allowed within this radius --> 
       <arg name="vicinity_radius" value="5.0"/>
 
+      <!-- Give everything time to discover -->
+      <arg name="discovery_timeout" value="15.0"/>
+
       <arg name="delay_threshold" value="1.0"/>
 
       <!-- Battery parameters -->

--- a/rmf_demos/launch/include/adapters/caddy_adapter.launch.xml
+++ b/rmf_demos/launch/include/adapters/caddy_adapter.launch.xml
@@ -25,8 +25,7 @@
       <arg name="vicinity_radius" value="5.0"/>
 
       <!-- Give everything time to discover -->
-      <arg name="discovery_timeout" value="15.0"/>
-
+      <arg name="discovery_timeout" value="60.0"/>
       <arg name="delay_threshold" value="1.0"/>
 
       <!-- Battery parameters -->


### PR DESCRIPTION
This issue which the caddy fleet adapter dies due to `"Timeout while trying to connect to traffic schedule"` happens in a time-to-time manner (I am using a slow machine). 

Similar to other robot adapters launch file, setting a longer `discovery timeout` param (default 10) solves this.