### PR TITLE
clean flask-cors rosdep

### DIFF
--- a/rmf_demos_panel/package.xml
+++ b/rmf_demos_panel/package.xml
@@ -8,8 +8,6 @@
   <license>Apache License 2.0</license>
 
   <exec_depend>python3-flask</exec_depend>
-  <exec_depend>python3-flask-cors</exec_depend>
-
   <exec_depend>rmf_fleet_msgs</exec_depend>
   <exec_depend>rmf_task_msgs</exec_depend>
   <exec_depend>rmf_demos_dashboard_resources</exec_depend>


### PR DESCRIPTION
Remove `flask-cors` since not avail during `rosdep` installation