### PR TITLE
refactoring to bring use_sim_time to a single global definition

### DIFF
--- a/rmf_demos/launch/airport_terminal.launch.xml
+++ b/rmf_demos/launch/airport_terminal.launch.xml
@@ -3,10 +3,11 @@
 <launch>
   <arg name="use_ignition" default="0"/>
   <arg name="gazebo_version" default="11"/>
+  <arg name="use_sim_time" default="true"/>
 
   <!-- Common launch -->
   <include file="$(find-pkg-share rmf_demos)/common.launch.xml">
-    <arg name="use_sim_time" value="true"/>
+    <arg name="use_sim_time" value="$(var use_sim_time)"/>
     <arg name="viz_config_file" value ="$(find-pkg-share rmf_demos)/include/airport_terminal/airport_terminal.rviz"/>
     <arg name="config_file" value="$(find-pkg-share rmf_demos_maps)/airport_terminal/airport_terminal.building.yaml"/>
     <arg name="dashboard_config_file" value="$(find-pkg-share rmf_demos_dashboard_resources)/airport_terminal/dashboard_config.json"/>
@@ -24,13 +25,13 @@
     <let name="fleet_name" value="tinyRobot"/>
     <include file="$(find-pkg-share rmf_demos)/include/adapters/tinyRobot_adapter.launch.xml">
       <arg name="fleet_name" value="$(var fleet_name)"/>
-      <arg name="use_sim_time" value="true"/>
+      <arg name="use_sim_time" value="$(var use_sim_time)"/>
       <arg name="nav_graph_file" value="$(find-pkg-share rmf_demos_maps)/maps/airport_terminal/nav_graphs/2.yaml" />
     </include>
     <include file="$(find-pkg-share rmf_fleet_adapter)/robot_state_aggregator.launch.xml">
       <arg name="robot_prefix" value="$(var fleet_name)"/>
       <arg name="fleet_name" value="$(var fleet_name)"/>
-      <arg name="use_sim_time" value="true"/>
+      <arg name="use_sim_time" value="$(var use_sim_time)"/>
     </include>
   </group>
 
@@ -39,13 +40,13 @@
     <let name="fleet_name" value="deliveryRobot"/>
     <include file="$(find-pkg-share rmf_demos)/include/adapters/deliveryRobot_adapter.launch.xml">
       <arg name="fleet_name" value="$(var fleet_name)"/>
-      <arg name="use_sim_time" value="true"/>
+      <arg name="use_sim_time" value="$(var use_sim_time)"/>
       <arg name="nav_graph_file" value="$(find-pkg-share rmf_demos_maps)/maps/airport_terminal/nav_graphs/1.yaml" />
     </include>
     <include file="$(find-pkg-share rmf_fleet_adapter)/robot_state_aggregator.launch.xml">
       <arg name="robot_prefix" value="$(var fleet_name)"/>
       <arg name="fleet_name" value="$(var fleet_name)"/>
-      <arg name="use_sim_time" value="true"/>
+      <arg name="use_sim_time" value="$(var use_sim_time)"/>
     </include>
   </group>
 
@@ -53,13 +54,13 @@
   <group>
     <let name="fleet_name" value="caddy"/>
     <include file="$(find-pkg-share rmf_demos)/include/adapters/caddy_adapter.launch.xml">
-      <arg name="use_sim_time" value="true"/>
+      <arg name="use_sim_time" value="$(var use_sim_time)"/>
       <arg name="fleet_name" value="$(var fleet_name)"/>
     </include>
     <include file="$(find-pkg-share rmf_fleet_adapter)/robot_state_aggregator.launch.xml">
       <arg name="robot_prefix" value="$(var fleet_name)"/>
       <arg name="fleet_name" value="$(var fleet_name)"/>
-      <arg name="use_sim_time" value="true"/>
+      <arg name="use_sim_time" value="$(var use_sim_time)"/>
     </include>
   </group>
 
@@ -74,7 +75,7 @@
     <include file="$(find-pkg-share rmf_fleet_adapter)/robot_state_aggregator.launch.xml">
       <arg name="robot_prefix" value="$(var fleet_name)"/>
       <arg name="fleet_name" value="$(var fleet_name)"/>
-      <arg name="use_sim_time" value="true"/>
+      <arg name="use_sim_time" value="$(var use_sim_time)"/>
     </include>
   </group>
 
@@ -89,7 +90,7 @@
     <include file="$(find-pkg-share rmf_fleet_adapter)/robot_state_aggregator.launch.xml">
       <arg name="robot_prefix" value="$(var fleet_name)"/>
       <arg name="fleet_name" value="$(var fleet_name)"/>
-      <arg name="use_sim_time" value="true"/>
+      <arg name="use_sim_time" value="$(var use_sim_time)"/>
     </include>
   </group>
 

--- a/rmf_demos/launch/battle_royale.launch.xml
+++ b/rmf_demos/launch/battle_royale.launch.xml
@@ -3,6 +3,7 @@
 <launch>
   <arg name="use_ignition" default="0"/>
   <arg name="gazebo_version" default="11"/>
+  <arg name="use_sim_time" default="true"/>
 
   <!-- Common launch -->
   <include file="$(find-pkg-share rmf_demos)/common.launch.xml">
@@ -29,7 +30,7 @@
     <include file="$(find-pkg-share rmf_fleet_adapter)/robot_state_aggregator.launch.xml">
       <arg name="robot_prefix" value="tinyRobot"/>
       <arg name="fleet_name" value="$(var fleet_name)"/>
-      <arg name="use_sim_time" value="true"/>
+      <arg name="use_sim_time" value="$(var use_sim_time)"/>
     </include>
   </group>
 

--- a/rmf_demos/launch/clinic.launch.xml
+++ b/rmf_demos/launch/clinic.launch.xml
@@ -3,6 +3,7 @@
 <launch>
   <arg name="use_ignition" default="0"/>
   <arg name="gazebo_version" default="11"/>
+  <arg name="use_sim_time" default="true"/>
 
   <!-- Common launch -->
   <include file="$(find-pkg-share rmf_demos)/common.launch.xml">
@@ -24,13 +25,13 @@
     <let name="fleet_name" value="deliveryRobot"/>
     <include file="$(find-pkg-share rmf_demos)/include/adapters/deliveryRobot_adapter.launch.xml">
       <arg name="fleet_name" value="$(var fleet_name)"/>
-      <arg name="use_sim_time" value="true"/>
+      <arg name="use_sim_time" value="$(var use_sim_time)"/>
       <arg name="nav_graph_file" value="$(find-pkg-share rmf_demos_maps)/maps/clinic/nav_graphs/0.yaml" />
     </include>
     <include file="$(find-pkg-share rmf_fleet_adapter)/robot_state_aggregator.launch.xml">
       <arg name="robot_prefix" value="deliveryRobot"/>
       <arg name="fleet_name" value="$(var fleet_name)"/>
-      <arg name="use_sim_time" value="true"/>
+      <arg name="use_sim_time" value="$(var use_sim_time)"/>
     </include>
   </group>
 
@@ -39,13 +40,13 @@
     <let name="fleet_name" value="tinyRobot"/>
     <include file="$(find-pkg-share rmf_demos)/include/adapters/tinyRobot_adapter.launch.xml">
       <arg name="fleet_name" value="$(var fleet_name)"/>
-      <arg name="use_sim_time" value="true"/>
+      <arg name="use_sim_time" value="$(var use_sim_time)"/>
       <arg name="nav_graph_file" value="$(find-pkg-share rmf_demos_maps)/maps/clinic/nav_graphs/1.yaml" />
     </include>
     <include file="$(find-pkg-share rmf_fleet_adapter)/robot_state_aggregator.launch.xml">
       <arg name="robot_prefix" value="tinyRobot"/>
       <arg name="fleet_name" value="$(var fleet_name)"/>
-      <arg name="use_sim_time" value="true"/>
+      <arg name="use_sim_time" value="$(var use_sim_time)"/>
     </include>
   </group>
 

--- a/rmf_demos/launch/experimental_hotel.launch.xml
+++ b/rmf_demos/launch/experimental_hotel.launch.xml
@@ -3,10 +3,11 @@
 <launch>
   <arg name="use_ignition" default="0"/>
   <arg name="gazebo_version" default="11"/>
+  <arg name="use_sim_time" default="true"/>
 
   <!-- Common launch -->
   <include file="$(find-pkg-share rmf_demos)/common.launch.xml">
-    <arg name="use_sim_time" value="true"/>
+    <arg name="use_sim_time" value="$(var use_sim_time)"/>
     <arg name="viz_config_file" value ="$(find-pkg-share rmf_demos)/include/hotel/hotel.rviz"/>
     <arg name="config_file" value="$(find-pkg-share rmf_demos_maps)/hotel/hotel.building.yaml"/>
   </include>
@@ -35,7 +36,7 @@
     <include file="$(find-pkg-share rmf_fleet_adapter)/robot_state_aggregator.launch.xml">
       <arg name="robot_prefix" value="TinyRobot"/>
       <arg name="fleet_name" value="$(var fleet_name)"/>
-      <arg name="use_sim_time" value="true"/>
+      <arg name="use_sim_time" value="$(var use_sim_time)"/>
     </include>
   </group>
 
@@ -52,7 +53,7 @@
     <include file="$(find-pkg-share rmf_fleet_adapter)/robot_state_aggregator.launch.xml">
       <arg name="robot_prefix" value="DeliveryRobot"/>
       <arg name="fleet_name" value="$(var fleet_name)"/>
-      <arg name="use_sim_time" value="true"/>
+      <arg name="use_sim_time" value="$(var use_sim_time)"/>
     </include>
   </group>
 

--- a/rmf_demos/launch/hotel.launch.xml
+++ b/rmf_demos/launch/hotel.launch.xml
@@ -3,10 +3,11 @@
 <launch>
   <arg name="use_ignition" default="0"/>
   <arg name="gazebo_version" default="11"/>
+  <arg name="use_sim_time" default="true"/>
 
   <!-- Common launch -->
   <include file="$(find-pkg-share rmf_demos)/common.launch.xml">
-    <arg name="use_sim_time" value="true"/>
+    <arg name="use_sim_time" value="$(var use_sim_time)"/>
     <arg name="viz_config_file" value ="$(find-pkg-share rmf_demos)/include/hotel/hotel.rviz"/>
     <arg name="config_file" value="$(find-pkg-share rmf_demos_maps)/hotel/hotel.building.yaml"/>
     <arg name="dashboard_config_file" value="$(find-pkg-share rmf_demos_dashboard_resources)/hotel/dashboard_config.json"/>
@@ -30,7 +31,7 @@
     <include file="$(find-pkg-share rmf_fleet_adapter)/robot_state_aggregator.launch.xml">
       <arg name="robot_prefix" value="TinyRobot"/>
       <arg name="fleet_name" value="$(var fleet_name)"/>
-      <arg name="use_sim_time" value="true"/>
+      <arg name="use_sim_time" value="$(var use_sim_time)"/>
     </include>
   </group>
 
@@ -45,7 +46,7 @@
     <include file="$(find-pkg-share rmf_fleet_adapter)/robot_state_aggregator.launch.xml">
       <arg name="robot_prefix" value="DeliveryRobot"/>
       <arg name="fleet_name" value="$(var fleet_name)"/>
-      <arg name="use_sim_time" value="true"/>
+      <arg name="use_sim_time" value="$(var use_sim_time)"/>
     </include>
   </group>
 

--- a/rmf_demos/launch/office.launch.xml
+++ b/rmf_demos/launch/office.launch.xml
@@ -3,10 +3,11 @@
 <launch>
   <arg name="use_ignition" default="0"/>
   <arg name="gazebo_version" default="11"/>
+  <arg name="use_sim_time" default="true"/>
 
   <!-- Common launch -->
   <include file="$(find-pkg-share rmf_demos)/common.launch.xml">
-    <arg name="use_sim_time" value="true"/>
+    <arg name="use_sim_time" value="$(var use_sim_time)"/>
     <arg name="viz_config_file" value ="$(find-pkg-share rmf_demos)/include/office/office.rviz"/>
     <arg name="config_file" value="$(find-pkg-share rmf_demos_maps)/office/office.building.yaml"/>
     <arg name="dashboard_config_file" value="$(find-pkg-share rmf_demos_dashboard_resources)/office/dashboard_config.json"/>
@@ -30,7 +31,7 @@
     <include file="$(find-pkg-share rmf_fleet_adapter)/robot_state_aggregator.launch.xml">
       <arg name="robot_prefix" value="tinyRobot"/>
       <arg name="fleet_name" value="$(var fleet_name)"/>
-      <arg name="use_sim_time" value="true"/>
+      <arg name="use_sim_time" value="$(var use_sim_time)"/>
     </include>
   </group>
 

--- a/rmf_demos/launch/office_mock_traffic_light.launch.xml
+++ b/rmf_demos/launch/office_mock_traffic_light.launch.xml
@@ -3,10 +3,11 @@
 <launch>
   <arg name="use_ignition" default="0"/>
   <arg name="gazebo_version" default="11"/>
+  <arg name="use_sim_time" default="true"/>
 
   <!-- Common launch -->
   <include file="$(find-pkg-share rmf_demos)/common.launch.xml">
-    <arg name="use_sim_time" value="true"/>
+    <arg name="use_sim_time" value="$(var use_sim_time)"/>
     <arg name="viz_config_file" value ="$(find-pkg-share rmf_demos)/include/office/office.rviz"/>
     <arg name="config_file" value="$(find-pkg-share rmf_demos_maps)/office/office.building.yaml"/>
     <arg name="dashboard_config_file" value="$(find-pkg-share rmf_demos_dashboard_resources)/office/dashboard_config.json"/>
@@ -29,7 +30,7 @@
     <include file="$(find-pkg-share rmf_fleet_adapter)/robot_state_aggregator.launch.xml">
       <arg name="robot_prefix" value="tinyRobot1"/>
       <arg name="fleet_name" value="tinyRobot1"/>
-      <arg name="use_sim_time" value="true"/>
+      <arg name="use_sim_time" value="$(var use_sim_time)"/>
     </include>
 
     <include file="$(find-pkg-share rmf_demos)/include/adapters/tinyRobot_mock_traffic_light.launch.xml">
@@ -40,7 +41,7 @@
     <include file="$(find-pkg-share rmf_fleet_adapter)/robot_state_aggregator.launch.xml">
       <arg name="robot_prefix" value="tinyRobot2"/>
       <arg name="fleet_name" value="tinyRobot2"/>
-      <arg name="use_sim_time" value="true"/>
+      <arg name="use_sim_time" value="$(var use_sim_time)"/>
     </include>
   </group>
 

--- a/rmf_demos/launch/triple_H.launch.xml
+++ b/rmf_demos/launch/triple_H.launch.xml
@@ -3,10 +3,11 @@
 <launch>
   <arg name="use_ignition" default="0"/>
   <arg name="gazebo_version" default="11"/>
+  <arg name="use_sim_time" default="true"/>
 
   <!-- Common launch -->
   <include file="$(find-pkg-share rmf_demos)/common.launch.xml">
-    <arg name="use_sim_time" value="true"/>
+    <arg name="use_sim_time" value="$(var use_sim_time)"/>
     <arg name="viz_config_file" value ="$(find-pkg-share rmf_demos)/include/triple_H/rviz.rviz"/>
     <arg name="config_file" value="$(find-pkg-share rmf_demos_maps)/triple_H/triple_H.building.yaml"/>
   </include>
@@ -29,7 +30,7 @@
     <include file="$(find-pkg-share rmf_fleet_adapter)/robot_state_aggregator.launch.xml">
       <arg name="robot_prefix" value="tinyRobot"/>
       <arg name="fleet_name" value="$(var fleet_name)"/>
-      <arg name="use_sim_time" value="true"/>
+      <arg name="use_sim_time" value="$(var use_sim_time)"/>
     </include>
   </group>
 


### PR DESCRIPTION
Signed-off-by: Boon Han <charayaphan.nakorn.boon.han@gmail.com>

## Bug fix
Inconsistent definition of `use_sim_time` parameter in nested launch files.

### Fix applied

Defined use_sim_time in the main launch file ( `office.launch.xml` ) and propogate this to all downstream launch files.
