### PR TITLE
add flag to automatically set gazebo update rate

### DIFF
--- a/rmf_demos/launch/airport_terminal.launch.xml
+++ b/rmf_demos/launch/airport_terminal.launch.xml
@@ -4,6 +4,7 @@
   <arg name="use_ignition" default="0"/>
   <arg name="gazebo_version" default="11"/>
   <arg name="use_sim_time" default="true"/>
+  <arg name="real_time_update_rate" default="1.0"/>
 
   <!-- Common launch -->
   <include file="$(find-pkg-share rmf_demos)/common.launch.xml">
@@ -18,6 +19,7 @@
     <arg name="map_name" value="airport_terminal" />
     <arg name="use_ignition" value="$(var use_ignition)" />
     <arg name="gazebo_version" value="$(var gazebo_version)" />
+    <arg name="real_time_update_rate" value="$(var real_time_update_rate)"/>
   </include>
 
   <!-- TinyRobot fleet adapter, and robot state aggregator needed for the TinyRobot slotcar_plugin -->

--- a/rmf_demos/launch/battle_royale.launch.xml
+++ b/rmf_demos/launch/battle_royale.launch.xml
@@ -4,6 +4,7 @@
   <arg name="use_ignition" default="0"/>
   <arg name="gazebo_version" default="11"/>
   <arg name="use_sim_time" default="true"/>
+  <arg name="real_time_update_rate" default="1.0"/>
 
   <!-- Common launch -->
   <include file="$(find-pkg-share rmf_demos)/common.launch.xml">
@@ -17,6 +18,7 @@
     <arg name="map_name" value="battle_royale" />
     <arg name="use_ignition" value="$(var use_ignition)" />
     <arg name="gazebo_version" value="$(var gazebo_version)" />
+    <arg name="real_time_update_rate" value="$(var real_time_update_rate)"/>
   </include>
 
   <!-- TinyRobot fleet adapter and robot state aggregator needed for the TinyRobot slotcar_plugin -->

--- a/rmf_demos/launch/clinic.launch.xml
+++ b/rmf_demos/launch/clinic.launch.xml
@@ -4,6 +4,7 @@
   <arg name="use_ignition" default="0"/>
   <arg name="gazebo_version" default="11"/>
   <arg name="use_sim_time" default="true"/>
+  <arg name="real_time_update_rate" default="1.0"/>
 
   <!-- Common launch -->
   <include file="$(find-pkg-share rmf_demos)/common.launch.xml">
@@ -18,6 +19,7 @@
     <arg name="map_name" value="clinic" />
     <arg name="use_ignition" value="$(var use_ignition)" />
     <arg name="gazebo_version" value="$(var gazebo_version)" />
+    <arg name="real_time_update_rate" value="$(var real_time_update_rate)"/>
   </include>
 
   <!-- DeliveryRobot fleet adapter and robot state aggregator needed for DeliveryRobot slotcar_plugin -->

--- a/rmf_demos/launch/experimental_hotel.launch.xml
+++ b/rmf_demos/launch/experimental_hotel.launch.xml
@@ -4,6 +4,7 @@
   <arg name="use_ignition" default="0"/>
   <arg name="gazebo_version" default="11"/>
   <arg name="use_sim_time" default="true"/>
+  <arg name="real_time_update_rate" default="1.0"/>
 
   <!-- Common launch -->
   <include file="$(find-pkg-share rmf_demos)/common.launch.xml">
@@ -17,6 +18,7 @@
     <arg name="map_name" value="hotel" />
     <arg name="use_ignition" value="$(var use_ignition)" />
     <arg name="gazebo_version" value="$(var gazebo_version)" />
+    <arg name="real_time_update_rate" value="$(var real_time_update_rate)"/>
   </include>
 
   <!-- Lift watchdog service launch -->

--- a/rmf_demos/launch/hotel.launch.xml
+++ b/rmf_demos/launch/hotel.launch.xml
@@ -4,6 +4,7 @@
   <arg name="use_ignition" default="0"/>
   <arg name="gazebo_version" default="11"/>
   <arg name="use_sim_time" default="true"/>
+  <arg name="real_time_update_rate" default="1.0"/>
 
   <!-- Common launch -->
   <include file="$(find-pkg-share rmf_demos)/common.launch.xml">
@@ -18,6 +19,7 @@
     <arg name="map_name" value="hotel" />
     <arg name="use_ignition" value="$(var use_ignition)" />
     <arg name="gazebo_version" value="$(var gazebo_version)" />
+    <arg name="real_time_update_rate" value="$(var real_time_update_rate)"/>
   </include>
 
   <!-- TinyRobot fleet adapter, and robot state aggregator needed for the TinyRobot slotcar_plugin -->

--- a/rmf_demos/launch/office.launch.xml
+++ b/rmf_demos/launch/office.launch.xml
@@ -4,6 +4,7 @@
   <arg name="use_ignition" default="0"/>
   <arg name="gazebo_version" default="11"/>
   <arg name="use_sim_time" default="true"/>
+  <arg name="real_time_update_rate" default="1.0"/>
 
   <!-- Common launch -->
   <include file="$(find-pkg-share rmf_demos)/common.launch.xml">
@@ -18,6 +19,7 @@
     <arg name="map_name" value="office" />
     <arg name="use_ignition" value="$(var use_ignition)" />
     <arg name="gazebo_version" value="$(var gazebo_version)" />
+    <arg name="real_time_update_rate" value="$(var real_time_update_rate)"/>
   </include>
 
   <!-- TinyRobot fleet adapter and robot state aggregator needed for the TinyRobot slotcar_plugin -->

--- a/rmf_demos/launch/office.launch.xml
+++ b/rmf_demos/launch/office.launch.xml
@@ -4,7 +4,7 @@
   <arg name="use_ignition" default="0"/>
   <arg name="gazebo_version" default="11"/>
   <arg name="use_sim_time" default="true"/>
-  <arg name="real_time_update_rate" default="1.0"/>
+  <arg name="real_time_update_rate" default="1000.0"/>
 
   <!-- Common launch -->
   <include file="$(find-pkg-share rmf_demos)/common.launch.xml">

--- a/rmf_demos/launch/office_mock_traffic_light.launch.xml
+++ b/rmf_demos/launch/office_mock_traffic_light.launch.xml
@@ -4,6 +4,7 @@
   <arg name="use_ignition" default="0"/>
   <arg name="gazebo_version" default="11"/>
   <arg name="use_sim_time" default="true"/>
+  <arg name="real_time_update_rate" default="1.0"/>
 
   <!-- Common launch -->
   <include file="$(find-pkg-share rmf_demos)/common.launch.xml">
@@ -18,6 +19,7 @@
     <arg name="map_name" value="office" />
     <arg name="use_ignition" value="$(var use_ignition)" />
     <arg name="gazebo_version" value="$(var gazebo_version)" />
+    <arg name="real_time_update_rate" value="$(var real_time_update_rate)"/>
   </include>
 
   <!-- TinyRobot fleet adapter and robot state aggregator needed for the TinyRobot slotcar_plugin -->

--- a/rmf_demos/launch/simulation.launch.xml
+++ b/rmf_demos/launch/simulation.launch.xml
@@ -5,6 +5,7 @@
   <arg name="map_name" description="Name of the rmf_demos map to simulate" />
   <arg name="use_ignition" default="0" />
   <arg name="use_crowdsim" default='0'/>
+  <arg name="real_time_update_rate" default="1.0"/>
 
   <!-- Gazebo classic was chosen-->
   <group unless="$(var use_ignition)">
@@ -24,6 +25,9 @@
       <env name="GAZEBO_PLUGIN_PATH" value="$(var plugin_path)" />
       <env name="GAZEBO_MODEL_DATABASE_URI" value="" />
       <env name="MENGE_RESOURCE_PATH" value="$(var menge_resource_path)"/>
+    </executable>
+    <executable cmd="bash -c &quot;sleep 10; gz physics -u $GAZEBO_REAL_TIME_UPDATE_RATE&quot;" output="both">
+      <env name="GAZEBO_REAL_TIME_UPDATE_RATE" value="$(var real_time_update_rate)" />
     </executable>
     <group unless="$(var headless)">
       <executable cmd="gzclient --verbose $(var world_path)" output="both">

--- a/rmf_demos/launch/triple_H.launch.xml
+++ b/rmf_demos/launch/triple_H.launch.xml
@@ -4,6 +4,7 @@
   <arg name="use_ignition" default="0"/>
   <arg name="gazebo_version" default="11"/>
   <arg name="use_sim_time" default="true"/>
+  <arg name="real_time_update_rate" default="1.0"/>
 
   <!-- Common launch -->
   <include file="$(find-pkg-share rmf_demos)/common.launch.xml">
@@ -17,6 +18,7 @@
     <arg name="map_name" value="triple_H" />
     <arg name="use_ignition" value="$(var use_ignition)" />
     <arg name="gazebo_version" value="$(var gazebo_version)" />
+    <arg name="real_time_update_rate" value="$(var real_time_update_rate)"/>
   </include>
 
   <!-- TinyRobot fleet adapter and robot state aggregator needed for the TinyRobot slotcar_plugin -->


### PR DESCRIPTION
Signed-off-by: Boon Han <charayaphan.nakorn.boon.han@gmail.com>

### Implemented feature
Proposing to add a somewhat "dirty" option to automatically set gazebo "real time update rate" to a given float. In current implementation, if the following flag is set ( for example ):
```
ros2 launch rmf_demos office.launch.xml real_time_update_rate:=0
```
then after the launch file is run, a 10 second countdown is run before the command `gz physics -u 0` is run which sets the real real update rate to 0 ( which brings the simulation to the max speed ).

The default is set to 1.0 ( real time ):
```
ros2 launch rmf_demos office.launch.xml real_time_update_rate:=1.0
```

Only implemented for classic gazebo for now as I'm unfamiliar with ignition.

