### PR TITLE
Fix/mock docker

### DIFF
--- a/rmf_demos_tasks/rmf_demos_tasks/mock_docker.py
+++ b/rmf_demos_tasks/rmf_demos_tasks/mock_docker.py
@@ -162,13 +162,13 @@ class MockDocker(Node):
         mode_request.robot_name = requested_path.robot_name
         mode_request.task_id = requested_path.task_id
         mode_request.mode.mode = RobotMode.MODE_PAUSED
-        for i in range(5):
-            self.mode_request_publisher.publish(mode_request)
-        self.get_logger().info(
-            f'{robot_name} done with docking at {finish_location}')
+        self.mode_request_publisher.publish(mode_request)
 
-        # Remove from watching
-        self.watching.pop(robot_name)
+        # Remove from watching, when it is no longer in Docking
+        if msg.mode.mode != RobotMode.MODE_DOCKING:
+            self.watching.pop(robot_name)
+            self.get_logger().info(
+                f'{robot_name} done with docking at {finish_location}')
 
 
 def main(argv=sys.argv):

--- a/rmf_demos_tasks/rmf_demos_tasks/mock_docker.py
+++ b/rmf_demos_tasks/rmf_demos_tasks/mock_docker.py
@@ -76,7 +76,7 @@ class MockDocker(Node):
             ModeRequest, 'robot_mode_requests', self.mode_request_cb, 1)
 
         self.robot_state_subscription = self.create_subscription(
-            RobotState, 'robot_state', self.robot_state_cb, 1)
+            RobotState, 'robot_state', self.robot_state_cb, 10)
 
         transient_qos = QoSProfile(
             history=History.RMW_QOS_POLICY_HISTORY_KEEP_LAST,

--- a/rmf_demos_tasks/rmf_demos_tasks/mock_docker.py
+++ b/rmf_demos_tasks/rmf_demos_tasks/mock_docker.py
@@ -73,7 +73,7 @@ class MockDocker(Node):
             ModeRequest, 'robot_mode_requests', 1)
 
         self.mode_request_subscription = self.create_subscription(
-            ModeRequest, 'robot_mode_requests', self.mode_request_cb, 1)
+            ModeRequest, 'robot_mode_requests', self.mode_request_cb, 10)
 
         self.robot_state_subscription = self.create_subscription(
             RobotState, 'robot_state', self.robot_state_cb, 10)

--- a/rmf_demos_tasks/rmf_demos_tasks/mock_docker.py
+++ b/rmf_demos_tasks/rmf_demos_tasks/mock_docker.py
@@ -125,7 +125,12 @@ class MockDocker(Node):
             print(f'Unexpected docking parameter [{msg.parameters[0]}]')
             return
 
-        dock = self.dock_map.get(msg.fleet_name).get(msg.parameters[0].value)
+        fleet_name = self.dock_map.get(msg.fleet_name)
+        if fleet_name is None:
+            print('Unknown fleet name reuested [{msg.fleet_name}].')
+            return
+
+        dock = fleet_name.get(msg.parameters[0].value)
         if not dock:
             print(f'Unknown dock name requested [{msg.parameters[0].value}]')
             return


### PR DESCRIPTION
Signed-off-by: Aaron Chong <aaronchongth@gmail.com>

<!--
For support requests, please read the Support Guidelines to know where to ask: https://github.com/open-rmf/rmf/wiki/Support-guidelines
For general questions and design discussion, please use the Discussions page: https://github.com/open-rmf/rmf/discussions
Not sure if this is the right repository? Open an issue on https://github.com/open-rmf/rmf
We require contributors to GPG Sign their commits. Follow the guide here to set up a GPG key and add it to your GitHub account: https://docs.github.com/en/github/authenticating-to-github/generating-a-new-gpg-key
A quick guide to how to sign your commits can be seen here: https://gist.github.com/mort3za/ad545d47dd2b54970c102fe39912f305
To GPG sign several commits at once (for example, if you forgot to sign some commits), you can run this command, followed by a force-push: git rebase --exec 'git commit --amend --no-edit -n -S' -i <commit before the first commit you want signed>
For bug fix pull requests, please fill out the information below.
Be as detailed as possible.
-->

## Bug fix

### Fixed bug

<!-- Briefly describe the bug being fixed.
If there is a bug report issue for the bug, link to that issue.
If there is not a bug report issue for the bug, create one first and fill out all the required information there, then link to that issue from this bug fix pull request. -->

* Fixes https://github.com/open-rmf/rmf_demos/issues/40, https://github.com/open-rmf/rmf_demos/issues/41, and https://github.com/open-rmf/rmf_demos/issues/43

### Fix applied

<!-- Describe in detail the approach taken, tools used, etc. to identify the cause of the bug and what was done to fix it. -->

* Checked `fleet_name` map is not a `None` type before proceeding
* Increased the `robot_state` and `robot_mode_request` subscription callback queue size to 10
* Publishes docking ending mode request once only
* Removes robot from `watching` only when robot is no longer in `Docking` mode

