### PR TITLE
fix caddy model and try teleop

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,11 @@ Non-autonomous vehicles can also be integrated with RMF provided their positions
 
 In the airport terminal map, a `Caddy` is spawned in the far right corner and can be controlled with `geometry_msgs/Twist` messages published over the `cmd_vel` topic. 
 
+Run `teleop_twist_keyboard` to control the `caddy` with your keyboard:
+```bash
+ros2 run teleop_twist_keyboard teleop_twist_keyboard
+```
+
 ![](../media/caddy.gif)
 
 ---

--- a/README.md
+++ b/README.md
@@ -122,7 +122,11 @@ In the airport terminal map, a `Caddy` is spawned in the far right corner and ca
 
 Run `teleop_twist_keyboard` to control the `caddy` with your keyboard:
 ```bash
+# Default launch with gazebo
 ros2 run teleop_twist_keyboard teleop_twist_keyboard
+
+# if launch with use_ignition:=1
+ros2 launch rmf_demos airport_terminal_caddy_ign.launch.xml
 ```
 
 ![](../media/caddy.gif)

--- a/rmf_demos_assets/models/Caddy/model.sdf
+++ b/rmf_demos_assets/models/Caddy/model.sdf
@@ -1261,9 +1261,6 @@
           <lower>-0.3</lower>
           <upper>0.3</upper>
         </limit>
-        <dynamics>
-          <damping>0.01</damping>
-        </dynamics>
         <use_parent_model_frame>true</use_parent_model_frame>
       </axis>
       <physics>


### PR DESCRIPTION
### Fix caddy model

Related to https://github.com/open-rmf/rmf_demos/issues/46. Seems that one of the of vehicle switch (for aesthetic) joint damping config is causing this issue. Similar to these `PolarisRanger` models in [fuel](https://app.ignitionrobotics.org/search;q=Polaris%20Ranger).

Quick fix by fixing the caddy's sdf.

For testing, 
1) launch `airport world`, 
2) use `gz physics -s 0.02`, 
3) run `ros2 run teleop_twist_keyboard teleop_twist_keyboard` to make sure caddy works.
