### PR TITLE
Use Ignition Fuel to download models

### DIFF
--- a/rmf_demos_maps/CMakeLists.txt
+++ b/rmf_demos_maps/CMakeLists.txt
@@ -41,7 +41,7 @@ foreach(path ${traffic_editor_paths})
     add_custom_command(
       DEPENDS ${map_path}
       COMMAND ros2 run rmf_building_map_tools building_map_generator gazebo ${map_path} ${output_world_path} ${output_model_dir}
-      COMMAND ros2 run rmf_building_map_tools building_map_model_downloader ${map_path}
+      COMMAND ros2 run rmf_building_map_tools building_map_model_downloader ${map_path} -f -e ~/.gazebo/models
       OUTPUT ${output_world_path}
       )
   endif()


### PR DESCRIPTION
## New feature implementation

### Implemented feature

Feature using Ignition Fuel tools to download models was added to `rmf_traffic_editor` [here](https://github.com/open-rmf/rmf_traffic_editor/pull/359). The models will still be downloaded to `~/.gazebo/models` as per before.

### Implementation description

Use the `-f` flag with the `-e` flag specifying the export folder of  `~/.gazebo/models`.
