### PR TITLE
Add ros_ign_bridge runtime dependency

### DIFF
--- a/rmf_demos/package.xml
+++ b/rmf_demos/package.xml
@@ -30,6 +30,7 @@
   <exec_depend>joy</exec_depend>
   <exec_depend>teleop_twist_joy</exec_depend>
   <exec_depend>launch_xml</exec_depend>
+  <exec_depend>ros_ign_bridge</exec_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
## Bug fix

### Fixed bug

Add the missing runtime dependency for `ros_ign_bridge`.

### Fix applied

`ros_ign_bridge` is used in all our demos when running in Ignition to bridge the clock topic between ROS and Ignition and keep them synchronized. It has been in the launch files for a long time but the dependency was missing, hence the fix