### PR TITLE
making models download location packaging friendly

### DIFF
--- a/rmf_demos_maps/CMakeLists.txt
+++ b/rmf_demos_maps/CMakeLists.txt
@@ -38,12 +38,21 @@ foreach(path ${traffic_editor_paths})
     )
   else()
     message("DOWNLOADING MODELS WITH COMMAND: ros2 run rmf_building_map_tools building_map_model_downloader ${map_path}")
-    add_custom_command(
-      DEPENDS ${map_path}
-      COMMAND ros2 run rmf_building_map_tools building_map_generator gazebo ${map_path} ${output_world_path} ${output_model_dir}
-      COMMAND ros2 run rmf_building_map_tools building_map_model_downloader ${map_path} -f -e ${output_model_dir}
-      OUTPUT ${output_world_path}
+    if(DEFINED ENV{RMF_DOWNLOAD_MODELS_HOME})
+      add_custom_command(
+        DEPENDS ${map_path}
+        COMMAND ros2 run rmf_building_map_tools building_map_generator gazebo ${map_path} ${output_world_path} ${output_model_dir}
+        COMMAND ros2 run rmf_building_map_tools building_map_model_downloader ${map_path} -f -e ~/.gazebo/models
+        OUTPUT ${output_world_path}
       )
+    else()
+      add_custom_command(
+        DEPENDS ${map_path}
+        COMMAND ros2 run rmf_building_map_tools building_map_generator gazebo ${map_path} ${output_world_path} ${output_model_dir}
+        COMMAND ros2 run rmf_building_map_tools building_map_model_downloader ${map_path} -f -e ${output_model_dir}
+        OUTPUT ${output_world_path}
+      )
+    endif()
   endif()
 
   ##############################################################################

--- a/rmf_demos_maps/CMakeLists.txt
+++ b/rmf_demos_maps/CMakeLists.txt
@@ -41,7 +41,7 @@ foreach(path ${traffic_editor_paths})
     add_custom_command(
       DEPENDS ${map_path}
       COMMAND ros2 run rmf_building_map_tools building_map_generator gazebo ${map_path} ${output_world_path} ${output_model_dir}
-      COMMAND ros2 run rmf_building_map_tools building_map_model_downloader ${map_path} -f -e ~/.gazebo/models
+      COMMAND ros2 run rmf_building_map_tools building_map_model_downloader ${map_path} -f -e ${output_model_dir}
       OUTPUT ${output_world_path}
       )
   endif()


### PR DESCRIPTION
Signed-off-by: Marco A. Gutierrez <marco@openrobotics.org>

## Bug fix

### Fixed bug

Models were being downloaded to the user's home directory at (almost) compilation time, which is fine when building from sources but not so fine when trying to package the sources.
### Fix applied

Models are now downloaded to a location relative to the package so they will be included in the future packaged `.deb` file.