### PR TITLE
remove requried attribute in xml launch file

### DIFF
--- a/rmf_demos/launch/airport_terminal.launch.xml
+++ b/rmf_demos/launch/airport_terminal.launch.xml
@@ -103,7 +103,7 @@
   <!-- Mock Docker Node, to provide Fleet Adapter fix cleaning task paths -->
   <group>
     <let name="docking_config_file" value="$(find-pkg-share rmf_demos_tasks)/airport_docker_config.yaml"/>
-    <node pkg="rmf_demos_tasks" exec="mock_docker" args="-c $(var docking_config_file)" required="true">
+    <node pkg="rmf_demos_tasks" exec="mock_docker" args="-c $(var docking_config_file)">
       <param name="use_sim_time" value="$(var use_sim_time)"/>
     </node>
   </group>


### PR DESCRIPTION
Signed-off-by: Marco A. Gutierrez <marco@openrobotics.org>

## Bug fix

### Fixed bug

Airport launch file throws an error when trying to run the demo:
```
...
launch.invalid_launch_file_error.InvalidLaunchFileError: Caught exception when trying to load file of format [xml]: Unexpected attribute(s) found in `node`: {'required'}
```

Even though the `required` attribute is supported for nodes on python launch files, based on the error above and the documentation found here: https://design.ros2.org/articles/roslaunch_xml.html it seems that it is not available on for `xml` launch files. 

I believe we are only getting this error now on `galactic` due to the changes introduced here: https://github.com/ros2/launch/pull/468.

### Fix applied

`required` attribute has been removed from launch file.