### PR TITLE
add test_ackman level

### DIFF
--- a/rmf_demos/launch/test_ackman.launch.xml
+++ b/rmf_demos/launch/test_ackman.launch.xml
@@ -19,19 +19,4 @@
     <arg name="gazebo_version" value="$(var gazebo_version)" />
   </include>
 
-  <!-- TinyRobot fleet adapter and robot state aggregator needed for the TinyRobot slotcar_plugin -->
-  <group>
-    <let name="fleet_name" value="tinyRobot"/>
-    <include file="$(find-pkg-share rmf_demos)/include/adapters/tinyRobot_mock_traffic_light.launch.xml">
-      <arg name="fleet_name" value="$(var fleet_name)"/>
-      <arg name="use_sim_time" value="$(var use_sim_time)"/>
-      <arg name="nav_graph_file" value="$(find-pkg-share rmf_demos_maps)/maps/test_ackman/nav_graphs/0.yaml" />
-    </include>
-    <include file="$(find-pkg-share rmf_fleet_adapter)/robot_state_aggregator.launch.xml">
-      <arg name="robot_prefix" value="tinyRobot"/>
-      <arg name="fleet_name" value="$(var fleet_name)"/>
-      <arg name="use_sim_time" value="$(var use_sim_time)"/>
-    </include>
-  </group>
-
 </launch>

--- a/rmf_demos_maps/maps/test_ackman/test_ackman.building.yaml
+++ b/rmf_demos_maps/maps/test_ackman/test_ackman.building.yaml
@@ -1,0 +1,65 @@
+crowd_sim:
+  agent_groups:
+    - {agents_name: [], agents_number: 0, group_id: 0, profile_selector: external_agent, state_selector: external_static, x: 0, y: 0}
+  agent_profiles:
+    - {ORCA_tau: 1, ORCA_tauObst: 0.4, class: 1, max_accel: 0, max_angle_vel: 0, max_neighbors: 10, max_speed: 0, name: external_agent, neighbor_dist: 5, obstacle_set: 1, pref_speed: 0, r: 0.25}
+  enable: 0
+  goal_sets: []
+  model_types: []
+  obstacle_set: {class: 1, file_name: L1_navmesh.nav, type: nav_mesh}
+  states:
+    - {final: 1, goal_set: -1, name: external_static, navmesh_file_name: ""}
+  transitions: []
+  update_time_step: 0.1
+levels:
+  L1:
+    elevation: 0
+    flattened_x_offset: 0
+    flattened_y_offset: 0
+    floors:
+      - parameters: {texture_name: [1, blue_linoleum], texture_rotation: [3, 0], texture_scale: [3, 1]}
+        vertices: [0, 10, 11, 17, 18]
+      - parameters: {texture_name: [1, blue_linoleum], texture_rotation: [3, 0], texture_scale: [3, 1]}
+        vertices: [11, 12, 19, 20, 17]
+      - parameters: {texture_name: [1, blue_linoleum], texture_rotation: [3, 0], texture_scale: [3, 1]}
+        vertices: [20, 16, 21, 13, 19]
+      - parameters: {texture_name: [1, blue_linoleum], texture_rotation: [3, 0], texture_scale: [3, 1]}
+        vertices: [21, 16, 15, 14]
+    lanes:
+      - [1, 2, {bidirectional: [4, false], demo_mock_floor_name: [1, ""], demo_mock_lift_name: [1, ""], graph_idx: [2, 0], orientation: [1, ""]}]
+      - [2, 3, {bidirectional: [4, false], demo_mock_floor_name: [1, ""], demo_mock_lift_name: [1, ""], graph_idx: [2, 0], orientation: [1, ""]}]
+      - [3, 8, {bidirectional: [4, false], demo_mock_floor_name: [1, ""], demo_mock_lift_name: [1, ""], graph_idx: [2, 0], orientation: [1, ""]}]
+      - [8, 7, {bidirectional: [4, false], demo_mock_floor_name: [1, ""], demo_mock_lift_name: [1, ""], graph_idx: [2, 0], orientation: [1, ""]}]
+      - [7, 4, {bidirectional: [4, false], demo_mock_floor_name: [1, ""], demo_mock_lift_name: [1, ""], graph_idx: [2, 0], orientation: [1, ""]}]
+      - [4, 5, {bidirectional: [4, false], demo_mock_floor_name: [1, ""], demo_mock_lift_name: [1, ""], graph_idx: [2, 0], orientation: [1, ""]}]
+    layers:
+      {}
+    models:
+      - {model_name: OpenRobotics/Ambulance, name: ambulance, static: false, x: 400.491, y: 690.441, yaw: 1.5708, z: 0}
+    vertices:
+      - [380.889, 702.755, 0, ""]
+      - [397.211, 687.554, 0, a1]
+      - [397.413, 654.328, 0, b1]
+      - [429.966, 654.784, 0, b2]
+      - [430.271, 613.713, 0, c2]
+      - [396.177, 614.329, 0, c1]
+      - [428.352, 689.027, 0, a2]
+      - [462.367, 613.865, 0, c3]
+      - [462.823, 654.784, 0, b3]
+      - [463.539, 688.458, 0, a3]
+      - [415.221, 703.057, 0, ""]
+      - [414.644, 673.254, 0, ""]
+      - [478.467, 673.822, 0, ""]
+      - [480.114, 594.8339999999999, 0, ""]
+      - [377.485, 595.249, 0, ""]
+      - [377.485, 629.288, 0, ""]
+      - [448.366, 628.978, 0, ""]
+      - [412.942, 640.066, 0, ""]
+      - [380.889, 640.917, 0, ""]
+      - [479.116, 639.761, 0, ""]
+      - [448.166, 639.761, 0, ""]
+      - [448.683, 594.681, 0, ""]
+    x_meters: 40
+    y_meters: 40
+lifts: {}
+name: test_ackman


### PR DESCRIPTION
Signed-off-by: ddengster <ed.fan@osrfoundation.org>

Add a simple level to test nonholonomic pathing.

To test: `ros2 launch rmf_demos test_ackman.launch.xml use_ignition:=1`
To get the ambulance moving (replace `a1` or `c1` with your desired goal points):
`ros2 run rmf_demos_tasks request_ackmann_path -p rmf_demos_maps -n maps/test_ackman/nav_graphs/0.yaml -s a1 -e c1 -i taskid123 -r ambulance`

![l1](https://user-images.githubusercontent.com/3326941/129695679-a24fdfaa-b496-4f97-872a-8c97fc35650f.png)

![image](https://user-images.githubusercontent.com/3326941/129696711-11237e33-7551-4961-b6fb-8eee407ac787.png)
