### PR TITLE
Improve CleanerBotA's wheel inertias

### DIFF
--- a/rmf_demos_assets/models/CleanerBotA/model.sdf
+++ b/rmf_demos_assets/models/CleanerBotA/model.sdf
@@ -109,7 +109,7 @@
     <!-- ====================================================== -->
     <!-- Left wheel link and revolute joint -->
     <!-- ====================================================== -->
-    
+
     <link name="tire_left">
       <pose>0 0.26 0.08 0 0 0</pose>
 
@@ -117,9 +117,9 @@
         <pose>0 0 0 0 0 0</pose>
         <mass>5.0</mass>
         <inertia>
-          <ixx>0.757897446874</ixx>
-          <iyy>1.302975553365</iyy>
-          <izz>0.757897446874</izz>
+          <ixx>0.02</ixx>
+          <iyy>0.02</iyy>
+          <izz>0.02</izz>
         </inertia>
       </inertial>
 
@@ -166,9 +166,9 @@
         <pose>0 0 0 0 0 0</pose>
         <mass>5.0</mass>
         <inertia>
-          <ixx>0.757897446874</ixx>
-          <iyy>1.302975553365</iyy>
-          <izz>0.757897446874</izz>
+          <ixx>0.02</ixx>
+          <iyy>0.02</iyy>
+          <izz>0.02</izz>
         </inertia>
       </inertial>
 


### PR DESCRIPTION
## Bug fix

### Fixed bug

<!-- Briefly describe the bug being fixed.
If there is a bug report issue for the bug, link to that issue.
If there is not a bug report issue for the bug, create one first and fill out all the required information there, then link to that issue from this bug fix pull request. -->

The inertias were too big for the wheels, resulting in jerky movement.

Before:

![cleanerbot_inertia](https://user-images.githubusercontent.com/5751272/133537727-bb5da1f6-f826-4f48-b30c-9fd0e1cb7e59.png)

After:

![image](https://user-images.githubusercontent.com/5751272/133537778-3c1c1be0-248f-4b7c-90da-aac8f3500d62.png)

Just the wheels, after:

![image](https://user-images.githubusercontent.com/5751272/133537814-bae2e6f2-065a-41e9-996d-33ad7b2c526a.png)

### Fix applied

<!-- Describe in detail the approach taken, tools used, etc. to identify the cause of the bug and what was done to fix it. -->

Calculated new inertias based on a sphere of radius 0.1 m and mass of 5 kg.

The same change was applied to the version 2 of this model: 

https://app.ignitionrobotics.org/OpenRobotics/fuel/models/CleanerBot1
