### PR TITLE
adding diff_drive dependencies for caddy

### DIFF
--- a/rmf_demos_gz/package.xml
+++ b/rmf_demos_gz/package.xml
@@ -18,6 +18,7 @@
   <exec_depend>joy</exec_depend>
   <exec_depend>teleop_twist_joy</exec_depend>
   <exec_depend>launch_xml</exec_depend>
+  <exec_depend>gazebo_plugins</exec_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/rmf_demos_ign/package.xml
+++ b/rmf_demos_ign/package.xml
@@ -17,6 +17,7 @@
 
   <exec_depend>teleop_twist_keyboard</exec_depend>
   <exec_depend>launch_xml</exec_depend>
+  <exec_depend>libignition-gazebo5-plugins</exec_depend>
 
   <exec_depend>ros_ign_bridge</exec_depend>
 


### PR DESCRIPTION
Signed-off-by: Marco A. Gutierrez <marco@openrobotics.org>

## Bug fix

### Fixed bug

The Caddy model has [this hack](https://github.com/open-rmf/rmf_demos/blob/8d17280eb6445af19ac702b2da919c3bf5591b8c/rmf_demos_assets/models/Caddy/model.sdf#L31) to use the `libgazebo_ros_diff_drive.so` and `libignition-gazebo-diff-drive-system.so` plugins whenever needed. However, these plugins have to be manually installed as they are not declared as a dependency anywhere.

### Fix applied
Technically the correct place for the dependency would be `rmf_demos_assets` but this would defeat the previous effort on dividing packages so people can install only `ignition` or `gazebo` demo related packages independently. Therefore I'm adding these dependencies to `rmf_demos_gz` and `rmf_demos_ign` respectively to solve the issue.
