### PR TITLE
relase fixes: changelog and version bump

### DIFF
--- a/rmf_demos/package.xml
+++ b/rmf_demos/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rmf_demos</name>
-  <version>1.3.1</version>
+  <version>1.3.2</version>
   <description>Common launch files for RMF demos</description>
   <maintainer email="yadunund@openrobotics.org">Yadunund</maintainer>
   <maintainer email="marco@openrobotics.org">Marco A. Gutiérrez</maintainer>

--- a/rmf_demos_assets/package.xml
+++ b/rmf_demos_assets/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rmf_demos_assets</name>
-  <version>1.3.1</version>
+  <version>1.3.2</version>
   <description>Models and other media used for RMF demos</description>
   <maintainer email="yadunund@openrobotics.org">Yadunund</maintainer>
   <maintainer email="marco@openrobotics.org">Marco A. Gutiérrez</maintainer>

--- a/rmf_demos_dashboard_resources/package.xml
+++ b/rmf_demos_dashboard_resources/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rmf_demos_dashboard_resources</name>
-  <version>1.3.1</version>
+  <version>1.3.2</version>
   <description>Resource pack for RMF dashboard</description>
   <maintainer email="matiasbavera@gmail.com">Matías Bavera</maintainer>
   <maintainer email="marco@openrobotics.org">Marco A. Gutiérrez</maintainer>

--- a/rmf_demos_gz/CHANGELOG.md
+++ b/rmf_demos_gz/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Changelog for package rmf_demos_gz
 
+1.3.1 (2021-11-30)
+------------------
+* Added `diff_drive` plugin dependencies for caddy (#111)
+* Modified plugin path to match `rmf_simulation` install (#108)
+
 1.3.0 (2021-09-08)
 ------------------
 * Provides launch files for running various demonstrations in gazebo

--- a/rmf_demos_gz/package.xml
+++ b/rmf_demos_gz/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rmf_demos_gz</name>
-  <version>1.3.1</version>
+  <version>1.3.2</version>
   <description>Launch files for RMF demos using the Gazebo simulator</description>
   <maintainer email="yadunund@openrobotics.org">Yadunund</maintainer>
   <maintainer email="marco@openrobotics.org">Marco A. Gutiérrez</maintainer>

--- a/rmf_demos_ign/CHANGELOG.md
+++ b/rmf_demos_ign/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Changelog for package rmf_demos_ign
 
+1.3.1 (2021-11-30)
+------------------
+* Added `diff_drive` plugin dependencies for caddy (#111)
+* Modified plugin path to match `rmf_simulation` install (#108)
+
 1.3.0 (2021-09-08)
 ------------------
 * Provides launch files for running various demonstrations in ignition-gazebo

--- a/rmf_demos_ign/package.xml
+++ b/rmf_demos_ign/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rmf_demos_ign</name>
-  <version>1.3.1</version>
+  <version>1.3.2</version>
   <description>Launch files for RMF demos using the Ignition simulator</description>
   <maintainer email="yadunund@openrobotics.org">Yadunund</maintainer>
   <maintainer email="luca@openrobotics.org">Luca Della Vedova</maintainer>

--- a/rmf_demos_maps/package.xml
+++ b/rmf_demos_maps/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rmf_demos_maps</name>
-  <version>1.3.1</version>
+  <version>1.3.2</version>
   <description>A package containing demo maps for rmf</description>
   <maintainer email="aaron@openrobotics.org">Aaron Chong</maintainer>
   <maintainer email="marco@openrobotics.org">Marco A. Gutiérrez</maintainer>

--- a/rmf_demos_panel/package.xml
+++ b/rmf_demos_panel/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rmf_demos_panel</name>
-  <version>1.3.1</version>
+  <version>1.3.2</version>
   <description>Web based RMF Demo Panel</description>
   <maintainer email="youliang@openrobotics.org">youliang</maintainer>
   <maintainer email="marco@openrobotics.org">Marco A. Gutiérrez</maintainer>

--- a/rmf_demos_tasks/package.xml
+++ b/rmf_demos_tasks/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rmf_demos_tasks</name>
-  <version>1.3.1</version>
+  <version>1.3.2</version>
   <description>A package containing scripts for demos</description>
   <author email= "grey@openrobotics.org">Grey</author>
   <maintainer email="yadunund@openrobotics.org">Yadunund</maintainer>


### PR DESCRIPTION
Signed-off-by: Marco A. Gutierrez <marco@openrobotics.org>

Merging changes to changeling and version bump to match those in `foxy` and `galactic` branches. Only releasing the following bug fixes:

- adding diff_drive dependencies for caddy (#111) 
- modify plugin path to match rmf_simulation install (#108) 

