### PR TITLE
fix rosdep key for ign gz plugins

### DIFF
--- a/rmf_demos_ign/package.xml
+++ b/rmf_demos_ign/package.xml
@@ -17,7 +17,7 @@
 
   <exec_depend>teleop_twist_keyboard</exec_depend>
   <exec_depend>launch_xml</exec_depend>
-  <exec_depend>libignition-gazebo5-plugins</exec_depend>
+  <exec_depend>ignition-gazebo5-plugins</exec_depend>
 
   <exec_depend>ros_ign_bridge</exec_depend>
 


### PR DESCRIPTION
## Bug fix

### Fixed bug

Package `rmf_demos_ign` was using the wrong key for the package `libignition-gazebo5-plugins`.

### Fix applied

The correct key is `ignition-gazebo5-plugins` as in:

https://github.com/ros/rosdistro/blob/6408c8a5f28d88816920ddd7f536e4e50f80a7c6/rosdep/base.yaml#L1837
