### PR TITLE
redesign_v2: update rmf-demos-panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,15 @@ There are two main modes of submitting tasks to RMF via the Panel:
 1. Submit a Task: Used to submit a single task.
 2. Submit a List of Tasks: Used to submit a batch of tasks. A `.json` file containing a list of tasks may be loaded via the `Choose file` button. Some example files are found in `rmf_demos_panel/task_lists`.
 
+**LATEST UPDATE: Display Task States**
+
+`task_state_uptates` are now published via websocket. To display task states on `rmf-panel`, specify `server_uri:="ws://localhost:7878"` during ros2 launch. Example:
+```
+ros2 launch rmf_demos_gz office.launch.xml server_uri:="ws://localhost:7878"
+```
+
+This will let RMF (websocket clients) to publish their states to port `7878`. In this case, rmf-panel's `api_simple_server` is the websocket server.
+
 ---
 
 ### Hotel World

--- a/rmf_demos/launch/dashboard.launch.xml
+++ b/rmf_demos/launch/dashboard.launch.xml
@@ -5,6 +5,7 @@
   <arg name="use_sim_time" default="true" description="Use the /clock topic for time to sync with simulation"/>
   <arg name="server_ip" default="0.0.0.0" description="RMF_demos simple api-server IP address"/>
   <arg name="server_port_num" default="8083" description="RMF_demos simple api-server Port number"/>
+  <arg name="ws_server_port_num" default="7878" description="RMF_demos ws server Port number"/>
   <arg name="dashboard_config_file" default="" description="Path to dashboard config for web rmf panel file"/>
 
   <!-- Dispatcher API Server -->
@@ -15,6 +16,7 @@
       <param name="use_sim_time" value="$(var use_sim_time)"/>
       <env name="RMF_DEMOS_API_SERVER_IP" value="$(var server_ip)" />
       <env name="RMF_DEMOS_API_SERVER_PORT" value="$(var server_port_num)" />
+      <env name="RMF_WS_SERVER_PORT" value="$(var ws_server_port_num)" />
       <env name="DASHBOARD_CONFIG_PATH" value="$(var dashboard_config_file)" />
     </node>
   </group>

--- a/rmf_demos_panel/package.xml
+++ b/rmf_demos_panel/package.xml
@@ -10,6 +10,7 @@
 
   <exec_depend>python3-flask</exec_depend>
   <exec_depend>python3-flask-cors</exec_depend>
+  <exec_depend>python3-websockets</exec_depend>
 
   <exec_depend>rmf_fleet_msgs</exec_depend>
   <exec_depend>rmf_task_msgs</exec_depend>

--- a/rmf_demos_panel/rmf_demos_panel/rmf_msg_observer.py
+++ b/rmf_demos_panel/rmf_demos_panel/rmf_msg_observer.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+
+# Copyright 2022 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Note: This is script is a code duplication of
+# https://github.com/open-rmf/rmf_ros2/blob/redesign_v2-pybind/rmf_fleet_adapter_python/scripts/rmf_msg_observer.py
+# Will soon consider of on recreating a util py module.
+
+
+import asyncio
+import websockets
+import json
+from typing import Callable, Optional, List, Dict, Tuple
+
+#####################################################################
+
+
+class RmfMsgType:
+    FleetState = "fleet_state_update"
+    TaskState = "task_state_update"
+    TaskLog = "task_log_update"
+    FleetLog = "fleet_log_update"
+
+
+"""
+This helper function filters the messy msg from the websocket
+and only return the useful data according to the provided filter args
+:param json_str:     input json string data
+:param msg_type:     type of msg which is to be filter out
+:param data_filter:  detailed filter different levels of the data obj
+:return:             return the filtered data in dictionary format
+"""
+
+
+def filter_rmf_msg(
+        json_str: str,
+        filters: Dict[RmfMsgType, List[str]] = {}
+) -> Optional[Tuple[RmfMsgType, Dict]]:
+    obj = json.loads(json_str)
+    if "type" not in obj:
+        print("ERRORRRR: type is not avail as json key")
+        return None
+
+    if obj["type"] not in filters:
+        return None
+
+    msg_type = obj["type"]
+    data = obj["data"]
+    if not filters[msg_type]:  # empty list
+        return msg_type, data
+
+    for filter in filters[msg_type]:
+        if filter not in data:
+            print(f" Key ERROR!!, indicated data_filter: "
+                  "[{filter}] is not avail in {data}")
+            return None
+
+        data = data[filter]
+    return msg_type, data
+
+
+#####################################################################
+class AsyncRmfMsgObserver:
+    """
+    This helper class filters the messy msg from RMF server
+    and only return the useful data according to the provided filter args
+    Note that this is a blocking class since spin is done internally.
+    :param callback_fn:  function callback when a filtered msg is received
+    :param server_url:   websocket server address
+    :param server_port:  websocket server port number
+    :param json_str:     input json string data
+    :param msg_type:     type of msg which is to be filter out
+    :param data_filter:  detailed filter different levels of the data obj
+    """
+
+    def __init__(self,
+                 callback_fn: Callable[[dict], None],
+                 server_url: str = "localhost",
+                 server_port: str = "7878",
+                 msg_filters: Dict[RmfMsgType, List[str]] = {}
+                 ):
+        print("Starting Websocket Server")
+        self.callback_fn = callback_fn
+        self.server_url = server_url
+        self.server_port = server_port
+        self.msg_filters = msg_filters
+
+    """
+    This is a blocking function, which will spin the RmfMsgObserver.
+    By default this server will spin forever. User can provide an
+    optional future arg to indicate when to end this observer
+    """
+
+    def spin(self, future=asyncio.Future()):
+        self.future = future
+        asyncio.run(self.__internal_spin())
+
+    async def __msg_handler(self, websocket, path):
+        try:
+            async for message in websocket:
+                ret_data = filter_rmf_msg(
+                    message, self.msg_filters)
+                if ret_data:
+                    # call the provided callback function
+                    msg_type, data = ret_data
+                    self.callback_fn(msg_type, data)
+        except Exception as e:
+            print('Waiting for reconnection')
+
+    async def __check_future(self):
+        while not self.future.done():
+            await asyncio.sleep(1)  # arbitrary loop freq check
+        print("Received exit signal")
+        # TODO(YL): debug the reason why future is not awaitable outside
+        # of the loop problem. Thweb_server_spinap_future(self.future)
+
+    async def __internal_spin(self):
+        async with websockets.serve(
+                self.__msg_handler, self.server_url, self.server_port):
+            await self.__check_future()

--- a/rmf_demos_panel/rmf_demos_panel/simple_api_server.py
+++ b/rmf_demos_panel/rmf_demos_panel/simple_api_server.py
@@ -31,8 +31,10 @@ from threading import Thread
 from flask import Flask, request, jsonify
 from flask_cors import CORS
 from flask_socketio import SocketIO, emit, disconnect
+import asyncio
 
 from rmf_demos_panel.dispatcher_client import DispatcherClient
+from rmf_demos_panel.rmf_msg_observer import AsyncRmfMsgObserver, RmfMsgType
 
 ###############################################################################
 
@@ -55,7 +57,9 @@ logging.basicConfig(level=logging.DEBUG,
 
 # default dashboard
 dashboard_config = {"world_name": "EMPTY_DASHBOARD_CONFIG",
-                    "task": {"Delivery": {}, "Loop": {}, "Clean": {}}}
+                    "valid_task": [],
+                    "task": {"Delivery": {}, "Loop": {}, "Clean": {}}
+                    }
 
 ###############################################################################
 
@@ -132,12 +136,26 @@ def broadcast_states():
             socketio.emit('robot_states', robots, broadcast=True, namespace=ns)
             socketio.emit('ros_time', ros_time, broadcast=True, namespace=ns)
             logging.debug(f" ROS Time: {ros_time} | "
-                          "active tasks: "
-                          f"{len(dispatcher_client.active_tasks_cache)}"
-                          " | terminated tasks: "
-                          f"{len(dispatcher_client.terminated_tasks_cache)}"
+                          " tasks: "
+                          f"{len(dispatcher_client.task_states_cache)}"
                           f" | active robots: {len(robots)}")
         time.sleep(2)
+
+
+def rmf_state_listener(port_num: str, done_fut: asyncio.Future):
+    def msg_callback(msg_type, data):
+        dispatcher_client.set_task_state(data)
+        # data["phases"] = {}
+        # print(f" \nReceived [{msg_type}] :: Data: \n   "
+        #     f"{data}")
+
+    observer = AsyncRmfMsgObserver(
+        msg_callback,
+        msg_filters={RmfMsgType.TaskState: []},
+        server_url="localhost",
+        server_port=port_num
+    )
+    observer.spin(done_fut)
 
 ###############################################################################
 
@@ -145,6 +163,7 @@ def broadcast_states():
 def main(args=None):
     server_ip = "0.0.0.0"
     port_num = 8083
+    ws_port_num = 7878
 
     if "RMF_DEMOS_API_SERVER_IP" in os.environ:
         server_ip = os.environ['RMF_DEMOS_API_SERVER_IP']
@@ -153,6 +172,10 @@ def main(args=None):
     if "RMF_DEMOS_API_SERVER_PORT" in os.environ:
         port_num = os.environ['RMF_DEMOS_API_SERVER_PORT']
         print(f"Set Server port to: {server_ip}:{port_num}")
+
+    if "RMF_WS_SERVER_PORT" in os.environ:
+        ws_port_num = os.environ['RMF_WS_SERVER_PORT']
+        print(f"Set RMF Websocket port to: localhost:{ws_port_num}")
 
     if "DASHBOARD_CONFIG_PATH" in os.environ:
         config_path = os.environ['DASHBOARD_CONFIG_PATH']
@@ -178,10 +201,18 @@ def main(args=None):
     broadcast_thread = Thread(target=broadcast_states, args=())
     broadcast_thread.start()
 
-    print(f"Starting RMF_Demos API Server: {server_ip}:{port_num}")
+    done_fut = asyncio.Future()
+    listener_thread = Thread(
+        target=rmf_state_listener, args=(ws_port_num, done_fut))
+    listener_thread.start()
+
+    print(f"Starting RMF_Demos API Server: {server_ip}:{port_num}, "
+          f"with ws://localhost:{ws_port_num}")
     app.run(host=server_ip, port=port_num, debug=False)
     dispatcher_client.destroy_node()
     rclpy.shutdown()
+    print("shutting down...")
+    done_fut.set_result(True)  # shutdown listner
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
For task redesign_v2: `rmf-panel` will not work when testing with the new task `redesign_v2`.  https://github.com/open-rmf/rmf_ros2/pull/168

For more serious users of web-based rmf, it is recommended to use `rmf-web`. However, `rmf-panel` is still handy for users to quickly test out `rmf_demos` with a simple web dashboard, so fixes are applied here.

In the `simple-api-server`
- update previous submit task srv call to new `task_api_requests`
- To listen to `task_state_updates`, a WebSocket server is setup in `simple-api-server` (default port 7878) 
- task cancellation `task_api_requests` is still not available. Will add it when the feature is fully tested.

## To Test

Similar to how we launch the world as before:

```
ros2 launch rmf_demos_gz office.launch.xml server_uri:="ws://localhost:7878"
```

Then open the same frontend dashboard to request and view tasks. https://open-rmf.github.io/rmf-panel-js/



p/s: if we wish to consolidate all PR to `redesign_v2` for the major merge, I can rebase this pr to `redesign_v2`.