### PR TITLE
Fix rosdep key for demo bridges

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ ros2 run rmf_demos_tasks  dispatch_loop -s room_2 -f dead_end -n 10 --use_sim_ti
 #### RobotManager Integration
 (Add instructions for RobotManager integration)
 ```
-apt install mosquitto
+apt install mosquitto mosquitto-clients
 ros2 run rmf_demos_bridges fleet_robotmanager_mqtt_bridge -y 31500 -x 22000
 mosquitto_sub -t /robot/status/00000000-0000-0000-0000-000000000001
 ```

--- a/rmf_demos_bridges/package.xml
+++ b/rmf_demos_bridges/package.xml
@@ -18,6 +18,6 @@
   <exec_depend>python3-paho-mqtt</exec_depend>
   <exec_depend>python3-yaml</exec_depend>
   <exec_depend>python3-pyproj</exec_depend>
-  <exec_depend>python3-socketio</exec_depend>
+  <exec_depend>python3-flask-socketio</exec_depend>
 
 </package>


### PR DESCRIPTION
For `rmf_demos_bridges` package: changed the rosdep key from `python3-socketio` (doesn't exist) to `python3-flask-socketio`.

Also added `mosquitto-clients` installation to the README instructions, I couldn't run `mosquitto_sub` without it.