### PR TITLE
Add parameter to force Ignition Version

### DIFF
--- a/rmf_demos_ign/launch/airport_terminal.launch.xml
+++ b/rmf_demos_ign/launch/airport_terminal.launch.xml
@@ -4,6 +4,7 @@
   <arg name="use_sim_time" default="true"/>
   <arg name="failover_mode" default="false"/>
   <arg name="use_tpe" default="false"/>
+  <arg name="ignition_version" default='6'/>
 
   <!-- Common launch -->
   <include file="$(find-pkg-share rmf_demos)/airport_terminal.launch.xml">
@@ -15,6 +16,7 @@
   <!-- Simulation launch -->
   <include file="$(find-pkg-share rmf_demos_ign)/simulation.launch.xml">
     <arg name="map_name" value="airport_terminal" />
+    <arg name="ignition_version" value="$(var ignition_version)" />
   </include>
 
 </launch>

--- a/rmf_demos_ign/launch/battle_royale.launch.xml
+++ b/rmf_demos_ign/launch/battle_royale.launch.xml
@@ -3,6 +3,7 @@
 <launch>
   <arg name="use_sim_time" default="true"/>
   <arg name="use_tpe" default="false"/>
+  <arg name="ignition_version" default='6'/>
 
   <!-- Common launch -->
   <include file="$(find-pkg-share rmf_demos)/battle_royale.launch.xml">
@@ -13,6 +14,7 @@
   <!-- Simulation launch -->
   <include file="$(find-pkg-share rmf_demos_ign)/simulation.launch.xml">
     <arg name="map_name" value="battle_royale" />
+    <arg name="ignition_version" value="$(var ignition_version)" />
   </include>
 
 </launch>

--- a/rmf_demos_ign/launch/campus.launch.xml
+++ b/rmf_demos_ign/launch/campus.launch.xml
@@ -4,6 +4,7 @@
   <arg name="use_sim_time" default="true"/>
   <arg name="failover_mode" default="false"/>
   <arg name="use_tpe" default="false"/>
+  <arg name="ignition_version" default='6'/>
 
   <!-- Common launch -->
   <include file="$(find-pkg-share rmf_demos)/campus.launch.xml">
@@ -15,6 +16,7 @@
   <!-- Simulation launch -->
   <include file="$(find-pkg-share rmf_demos_ign)/simulation.launch.xml">
     <arg name="map_name" value="campus" />
+    <arg name="ignition_version" value="$(var ignition_version)" />
   </include>
 
 </launch>

--- a/rmf_demos_ign/launch/clinic.launch.xml
+++ b/rmf_demos_ign/launch/clinic.launch.xml
@@ -4,6 +4,7 @@
   <arg name="use_sim_time" default="true"/>
   <arg name="failover_mode" default="false"/>
   <arg name="use_tpe" default="false"/>
+  <arg name="ignition_version" default='6'/>
 
   <!-- Common launch -->
   <include file="$(find-pkg-share rmf_demos)/clinic.launch.xml">
@@ -15,6 +16,7 @@
   <!-- Simulation launch -->
   <include file="$(find-pkg-share rmf_demos_ign)/simulation.launch.xml">
     <arg name="map_name" value="clinic" />
+    <arg name="ignition_version" value="$(var ignition_version)" />
   </include>
 
 </launch>

--- a/rmf_demos_ign/launch/hotel.launch.xml
+++ b/rmf_demos_ign/launch/hotel.launch.xml
@@ -4,6 +4,7 @@
   <arg name="use_sim_time" default="true"/>
   <arg name="failover_mode" default="false"/>
   <arg name="use_tpe" default="false"/>
+  <arg name="ignition_version" default='6'/>
 
   <!-- Common launch -->
   <include file="$(find-pkg-share rmf_demos)/hotel.launch.xml">
@@ -15,5 +16,6 @@
   <!-- Simulation launch -->
   <include file="$(find-pkg-share rmf_demos_ign)/simulation.launch.xml">
     <arg name="map_name" value="hotel" />
+    <arg name="ignition_version" value="$(var ignition_version)" />
   </include>
 </launch>

--- a/rmf_demos_ign/launch/office.launch.xml
+++ b/rmf_demos_ign/launch/office.launch.xml
@@ -4,6 +4,7 @@
   <arg name="use_sim_time" default="true"/>
   <arg name="failover_mode" default="false"/>
   <arg name="use_tpe" default="false"/>
+  <arg name="ignition_version" default='6'/>
 
   <!-- Common launch -->
   <include file="$(find-pkg-share rmf_demos)/office.launch.xml">
@@ -15,6 +16,7 @@
   <!-- Simulation launch -->
   <include file="$(find-pkg-share rmf_demos_ign)/simulation.launch.xml">
     <arg name="map_name" value="office" />
+    <arg name="ignition_version" value="$(var ignition_version)" />
   </include>
 
 </launch>

--- a/rmf_demos_ign/launch/office_mock_traffic_light.launch.xml
+++ b/rmf_demos_ign/launch/office_mock_traffic_light.launch.xml
@@ -3,6 +3,7 @@
 <launch>
   <arg name="use_sim_time" default="true"/>
   <arg name="use_tpe" default="false"/>
+  <arg name="ignition_version" default='6'/>
 
   <!-- Common launch -->
   <include file="$(find-pkg-share rmf_demos)/office_mock_traffic_light.launch.xml">
@@ -13,6 +14,7 @@
   <!-- Simulation launch -->
   <include file="$(find-pkg-share rmf_demos_ign)/simulation.launch.xml">
     <arg name="map_name" value="office" />
+    <arg name="ignition_version" value="$(var ignition_version)" />
   </include>
 
 </launch>

--- a/rmf_demos_ign/launch/simulation.launch.xml
+++ b/rmf_demos_ign/launch/simulation.launch.xml
@@ -5,6 +5,7 @@
   <arg name="map_name" description="Name of the rmf_demos map to simulate" />
   <arg name="use_crowdsim" default='0'/>
   <arg name="use_tpe" default='0'/>
+  <arg name="ignition_version" default='6'/>
 
   <let name="world_path" value="$(find-pkg-share $(var map_package))/maps/$(var map_name)_ign/$(var map_name).world" />
   <let name="model_path" value="$(find-pkg-share $(var map_package))/maps/$(var map_name)/models:$(find-pkg-share $(var map_package))/maps/$(var map_name)_ign/models:$(find-pkg-share rmf_demos_assets)/models:$(env HOME)/.gazebo/models" />
@@ -22,7 +23,7 @@
   <let name="ign_headless" unless="$(var headless)" value="" />
 
   <group unless="$(var use_tpe)">
-    <executable cmd="ign gazebo $(var ign_headless) $(var tpe_engine) -r -v 4 $(var world_path)" output="both">
+    <executable cmd="ign gazebo --force-version $(var ignition_version) $(var ign_headless) $(var tpe_engine) -r -v 4 $(var world_path)" output="both">
       <env name="IGN_GAZEBO_RESOURCE_PATH" value="$(var model_path):$(var world_path)" />
       <env name="IGN_GAZEBO_SYSTEM_PLUGIN_PATH" value="$(var plugin_path)"/>
       <env name="IGN_GUI_PLUGIN_PATH" value="$(var plugin_path)"/>

--- a/rmf_demos_ign/launch/triple_H.launch.xml
+++ b/rmf_demos_ign/launch/triple_H.launch.xml
@@ -3,6 +3,7 @@
 <launch>
   <arg name="use_sim_time" default="true"/>
   <arg name="use_tpe" default="false"/>
+  <arg name="ignition_version" default='6'/>
 
   <!-- Common launch -->
   <include file="$(find-pkg-share rmf_demos)/triple_H.launch.xml">
@@ -13,6 +14,7 @@
   <!-- Simulation launch -->
   <include file="$(find-pkg-share rmf_demos_ign)/simulation.launch.xml">
     <arg name="map_name" value="triple_H" />
+    <arg name="ignition_version" value="$(var ignition_version)" />
   </include>
 
 </launch>


### PR DESCRIPTION
## New feature implementation

### Implemented feature

This PR adds a parameter to force the Ignition Gazebo version when running `rmf_demos_ign` launch files.

### Implementation description

The plugins in [rmf_simulation](https://github.com/open-rmf/rmf_simulation/) are compiled against a specific version of Ignition Gazebo and if a different version of Ignition than the one used to compile the plugins was to be ran, the simulation would crash.
By default, the `ign gazebo` CLI runs the most recent version of Gazebo, hence if a user was to install a newer version than the one supported demos would stop working.

This PR introduces a `ignition_version` parameter to `rmf_demos_ign` that defaults to the version plugins are built against. Since it specifies Fortress it should be merged together with https://github.com/open-rmf/rmf_simulation/pull/70 to complete our migration. Users who wish to use different Ignition version can change the parameter value by doing, for example:

`ros2 launch rmf_demos_ign office.launch.xml ignition_version:=6`