### PR TITLE
Added instructions to change `server_uri` when using `rmf-web` dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ A near-term roadmap of the RMF project can be found in the user manual [here](ht
 
 Full web application of RMF: [rmf-web](https://github.com/open-rmf/rmf-web).
 
+In order to interact with the default configuration of the web application, the `server_uri` launch parameter will need to be changed to `ws://localhost:8001`, for example,
+
+```bash
+ros2 launch rmf_demos_ign office.launch.xml server_uri:="ws://localhost:8001"
+```
+
 ## Demo Worlds
 
 * [Hotel World](#Hotel-World)


### PR DESCRIPTION
Signed-off-by: Aaron Chong <aaronchongth@gmail.com>

<!--
For support requests, please read the Support Guidelines to know where to ask: https://github.com/open-rmf/rmf/wiki/Support-guidelines
For general questions and design discussion, please use the Discussions page: https://github.com/open-rmf/rmf/discussions
Not sure if this is the right repository? Open an issue on https://github.com/open-rmf/rmf
We require contributors to GPG Sign their commits. Follow the guide here to set up a GPG key and add it to your GitHub account: https://docs.github.com/en/github/authenticating-to-github/generating-a-new-gpg-key
A quick guide to how to sign your commits can be seen here: https://gist.github.com/mort3za/ad545d47dd2b54970c102fe39912f305
To GPG sign several commits at once (for example, if you forgot to sign some commits), you can run this command, followed by a force-push: git rebase --exec 'git commit --amend --no-edit -n -S' -i <commit before the first commit you want signed>
For bug fix pull requests, please fill out the information below.
Be as detailed as possible.
-->

## Documentation

Adding the instruction to target the `server_uri` launch parameter when using the web dashboard.
