### PR TITLE
[Humble] - Change experimental lift watchdog variable to not scoped

### DIFF
--- a/rmf_demos/launch/hotel.launch.xml
+++ b/rmf_demos/launch/hotel.launch.xml
@@ -14,14 +14,14 @@
   </include>
 
   <!-- Experimental Lift watchdog service launch, default disable -->
-  <group if="$(var enable_experimental_lift_watchdog)">
+  <group if="$(var enable_experimental_lift_watchdog)" scoped="false">
     <node pkg="rmf_fleet_adapter"
           exec="experimental_lift_watchdog"
           name="experimental_lift_watchdog"
           output="both" />
     <set_env name="EXPT_LIFT_WATCHDOG_SRV" value="experimental_lift_watchdog"/>
   </group>
-  <group unless="$(var enable_experimental_lift_watchdog)">
+  <group unless="$(var enable_experimental_lift_watchdog)" scoped="false">
     <set_env name="EXPT_LIFT_WATCHDOG_SRV" value=""/>
   </group>
 


### PR DESCRIPTION
## Bug fix

### Fixed bug

Starting from Humble, by default set_env calls are [scoped](https://docs.ros.org/en/foxy/Releases/Release-Humble-Hawksbill.html#scoping-environment-variables-in-group-actions) in the group where they are contained, this caused the hotel world to fail launching since `EXPT_LIFT_WATCHDOG_SRV` would not be set.

### Fix applied

Added the `scoped=false` override so other groups (the fleet adapter) can access the value.