### PR TITLE
Fix deprecation warnings for setup.cfg

### DIFF
--- a/rmf_demos_panel/setup.cfg
+++ b/rmf_demos_panel/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/rmf_demos_panel
+script_dir=$base/lib/rmf_demos_panel
 [install]
-install-scripts=$base/lib/rmf_demos_panel
+install_scripts=$base/lib/rmf_demos_panel

--- a/rmf_demos_tasks/setup.cfg
+++ b/rmf_demos_tasks/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/rmf_demos_tasks
+script_dir=$base/lib/rmf_demos_tasks
 [install]
-install-scripts=$base/lib/rmf_demos_tasks
+install_scripts=$base/lib/rmf_demos_tasks


### PR DESCRIPTION
## Bug fix

### Fixed bug

Same as https://github.com/open-rmf/rmf_visualization/pull/45, removes deprecation  warnings, possibly helping with Python path issues in the newer versions of colcon