### PR TITLE
Minor fixes for demo fleet adapter

### DIFF
--- a/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/RobotCommandHandle.py
+++ b/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/RobotCommandHandle.py
@@ -364,7 +364,7 @@ class RobotCommandHandle(adpt.RobotCommandHandle):
                     self.name, self.dock_name, self.map_name)):
                 self.node.get_logger().info(
                     f"Requesting robot {self.name} "
-                    "to dock at {self.dock_name}")
+                    f"to dock at {self.dock_name}")
                 self.sleep_for(1.0)
 
             with self._lock:

--- a/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/RobotCommandHandle.py
+++ b/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/RobotCommandHandle.py
@@ -365,7 +365,7 @@ class RobotCommandHandle(adpt.RobotCommandHandle):
                 self.node.get_logger().info(
                     f"Requesting robot {self.name} "
                     "to dock at {self.dock_name}")
-                time.sleep_for(1.0)
+                self.sleep_for(1.0)
 
             with self._lock:
                 self.on_waypoint = None

--- a/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/fleet_manager.py
+++ b/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/fleet_manager.py
@@ -275,6 +275,7 @@ class FleetManager(Node):
             cur_yaw = cur_loc.yaw
             previous_wp = [cur_x, cur_y, cur_yaw]
             target_loc = Location()
+            path_request.path.append(cur_loc)
             for wp in self.docks[task.task]:
                 target_loc = wp
                 path_request.path.append(target_loc)


### PR DESCRIPTION
Fixes small bugs including:
- formatting
- `slotcar` deletes the first waypoint when it receives a `PathRequest`, so it doesn't receive the target waypoint proper during docking. This PR appends the robot's current waypoint to the dock `PathRequest` (which was done similarly in `navigate()`)