### PR TITLE
Fix teleop action

### DIFF
--- a/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/RobotClientAPI.py
+++ b/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/RobotClientAPI.py
@@ -187,6 +187,24 @@ class RobotAPI:
             return response['data'].get('replan', False)
         return False
 
+    def toggle_action(self, robot_name: str, toggle: bool):
+        '''Request to toggle the robot's mode_teleop parameter.
+           Return True if the toggle request is successful'''
+        url = self.prefix +\
+            f"/open-rmf/rmf_demos_fm/toggle_action?robot_name={robot_name}"
+        data = {'toggle': toggle}
+        try:
+            response = requests.post(url, timeout=self.timeout, json=data)
+            response.raise_for_status()
+            if self.debug:
+                print(f'Response: {response.json()}')
+            return response.json()['success']
+        except HTTPError as http_err:
+            print(f'HTTP error: {http_err}')
+        except Exception as err:
+            print(f'Other error: {err}')
+        return False
+
     def data(self, robot_name=None):
         if robot_name is None:
             url = self.prefix + f'/open-rmf/rmf_demos_fm/status/'

--- a/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/RobotCommandHandle.py
+++ b/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/RobotCommandHandle.py
@@ -119,6 +119,7 @@ class RobotCommandHandle(adpt.RobotCommandHandle):
         # The graph index of the waypoint the robot starts or ends an action
         self.action_waypoint_index = None
         self.current_cmd_id = 0
+        self.started_action = False
 
         # Threading variables
         self._lock = threading.Lock()
@@ -539,6 +540,9 @@ class RobotCommandHandle(adpt.RobotCommandHandle):
                     self.position, self.dock_waypoint_index)
             # if robot is performing an action
             elif (self.action_execution is not None):
+                if not self.started_action:
+                    self.started_action = True
+                    self.api.toggle_action(self.name, self.started_action)
                 self.update_handle.update_off_grid_position(
                     self.position, self.action_waypoint_index)
             # if robot is merging into a waypoint
@@ -662,6 +666,8 @@ class RobotCommandHandle(adpt.RobotCommandHandle):
                 return
             self.action_execution.finished()
             self.action_execution = None
+            self.started_action = False
+            self.api.toggle_action(self.name, self.started_action)
             self.node.get_logger().info(f"Robot {self.name} has completed the"
                                         f" action it was performing")
 

--- a/rmf_demos_tasks/rmf_demos_tasks/teleop_robot.py
+++ b/rmf_demos_tasks/rmf_demos_tasks/teleop_robot.py
@@ -48,7 +48,8 @@ class Requester(Node):
         self.args = parser.parse_args(argv[1:])
 
         self.pub = self.create_publisher(
-          PathRequest, 'robot_path_requests', 1)
+          PathRequest, 'robot_path_requests',
+          qos_profile=qos_profile_system_default)
 
         msg = PathRequest()
         msg.fleet_name = self.args.fleet


### PR DESCRIPTION
This PR fixes a bug where the robot doesn't carry out a teleop action sent externally via the `teleop_robot` script due to:
- Incompatible QoS when publishing to `/robot_path_requests`
- Fleet manager checks whether the `/robot_state` and internally stored task_id's match and republishes the last PathRequest if they don't. This interrupts the robot when carrying out the teleop action, which carries a different task_id since it was sent directly to slotcar. 

This fix checks that the `/robot_state` task_id is a valid uuid and if so, it assumes that the robot is carrying out a teleop action (instead of the robot state update being out of date). It also checks whether the last PathRequest has been completed successfully before republishing it to slotcar.