### PR TITLE
Update attach/detach cart action

### DIFF
--- a/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/RobotClientAPI.py
+++ b/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/RobotClientAPI.py
@@ -93,12 +93,11 @@ class RobotAPI:
         return False
 
     def retrieve_process_waypoints(self,
-                                   process: dict):
+                                   process: str):
         ''' Returns the list of waypoints for a given process.'''
+        url = self.prefix +\
+            f'/open-rmf/rmf_demos_fm/process_waypoints?process={process}'
         try:
-            process_name = process['description']['task_name']
-            url = self.prefix +\
-                f'/open-rmf/rmf_demos_fm/process_waypoints?process={process_name}'
             response = requests.get(url, timeout=self.timeout)
             response.raise_for_status()
             if self.debug:
@@ -106,8 +105,6 @@ class RobotAPI:
             if not response.json()['success']:
                 return None
             return response.json()['data']['path']
-        except KeyError:
-            return None
         except HTTPError as http_err:
             print(f'HTTP error: {http_err}')
         except Exception as err:
@@ -117,7 +114,7 @@ class RobotAPI:
     def start_process(self,
                       robot_name: str,
                       cmd_id: int,
-                      process: dict,
+                      process: str,
                       map_name: str):
         ''' Request the robot to begin a process. This is specific to the robot
             and the use case. For example, load/unload a cart for Deliverybot
@@ -126,8 +123,8 @@ class RobotAPI:
         url = self.prefix +\
             f"/open-rmf/rmf_demos_fm/start_task?robot_name={robot_name}" \
             f"&cmd_id={cmd_id}"
-        # data fields: destination{}, data{}
-        data = {'data': process}
+        # data fields: task, map_name, destination{}, data{}
+        data = {'task': process, 'map_name': map_name}
         try:
             response = requests.post(url, timeout=self.timeout, json=data)
             response.raise_for_status()

--- a/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/RobotCommandHandle.py
+++ b/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/RobotCommandHandle.py
@@ -507,7 +507,7 @@ class RobotCommandHandle(adpt.RobotCommandHandle):
             self.api.start_process(
                 self.name, cmd_id, task_name, self.map_name)
             self.node.get_logger().info(
-                f'Robot [{self.name}] is executing perform action [{task_name}]')
+                f'Robot [{self.name}] is executing action [{task_name}]')
 
             while not self.api.process_completed(self.name, cmd_id):
                 if self.action_execution is None:

--- a/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/RobotCommandHandle.py
+++ b/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/RobotCommandHandle.py
@@ -489,9 +489,14 @@ class RobotCommandHandle(adpt.RobotCommandHandle):
         self._quit_action_event.clear()
         self.started_action = True
 
-        category = self.action_description['category']
-        if category == 'teleop':
-            # Teleop is a manual process where RMF releases control,
+        task_name = None
+        for desc_key in self.action_description.keys():
+            if '_task_name' in desc_key:
+                task_name = self.action_description[desc_key]
+                break
+        if task_name is None:
+            # If there is no task name, it is possible that this action is
+            # a manual process where RMF releases control, e.g. teleop
             # An /action_execution_notice should be published manually to
             # end the action
             return
@@ -500,9 +505,9 @@ class RobotCommandHandle(adpt.RobotCommandHandle):
             wps = self.api.retrieve_process_waypoints(self.action_description)
 
             self.api.start_process(
-                self.name, cmd_id, self.action_description, self.map_name)
+                self.name, cmd_id, task_name, self.map_name)
             self.node.get_logger().info(
-                f'Robot [{self.name}] is executing perform action {category}')
+                f'Robot [{self.name}] is executing perform action [{task_name}]')
 
             while not self.api.process_completed(self.name, cmd_id):
                 if self.action_execution is None:

--- a/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/fleet_adapter.py
+++ b/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/fleet_adapter.py
@@ -179,8 +179,7 @@ def initialize_fleet(config_yaml, nav_graph_path, node, use_sim_time):
                         cmd_handle.last_known_waypoint_index
                 cmd_handle.on_waypoint = None
                 cmd_handle.on_lane = None
-                cmd_handle.action_description = \
-                    {'category': category, 'description': description}
+                cmd_handle.action_description = description
                 cmd_handle.action_execution = execution
         # Set the action_executioner for the robot
         cmd_handle.update_handle.set_action_executor(_action_executor)

--- a/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/fleet_manager.py
+++ b/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/fleet_manager.py
@@ -435,6 +435,9 @@ class FleetManager(Node):
             if (robot.destination is None and robot.perform_action_mode):
                 if (msg.mode.mode == RobotMode.MODE_ACTION_COMPLETED):
                     completed_request = msg.mode.mode_request_id
+                    msg = self._make_mode_request(msg.name, msg.mode.mode_request_id + 1,
+                                                  RobotMode.MODE_IDLE)
+                    self.mode_pub.publish(msg)
                 elif (msg.mode.mode != RobotMode.MODE_ATTACHING_CART and
                       msg.mode.mode != RobotMode.MODE_ACTION_COMPLETED):
                     self.get_logger().info(f'Robot [{msg.name}] attach cart '

--- a/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/fleet_manager.py
+++ b/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/fleet_manager.py
@@ -435,7 +435,8 @@ class FleetManager(Node):
             if (robot.destination is None and robot.perform_action_mode):
                 if (msg.mode.mode == RobotMode.MODE_ACTION_COMPLETED):
                     completed_request = msg.mode.mode_request_id
-                    msg = self._make_mode_request(msg.name, msg.mode.mode_request_id + 1,
+                    msg = self._make_mode_request(msg.name,
+                                                  msg.mode.mode_request_id + 1,
                                                   RobotMode.MODE_IDLE)
                     self.mode_pub.publish(msg)
                 elif (msg.mode.mode != RobotMode.MODE_ATTACHING_CART and

--- a/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/fleet_manager.py
+++ b/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/fleet_manager.py
@@ -432,10 +432,15 @@ class FleetManager(Node):
             completed_request = None
 
             # Check if robot completed an action without destination
-            if (robot.destination is None and
-                    msg.mode.mode == RobotMode.MODE_IDLE and
-                    robot.perform_action_mode):
-                completed_request = msg.mode.mode_request_id
+            if (robot.destination is None and robot.perform_action_mode):
+                if (msg.mode.mode == RobotMode.MODE_ACTION_COMPLETED):
+                    completed_request = msg.mode.mode_request_id
+                elif (msg.mode.mode != RobotMode.MODE_ATTACHING_CART and
+                      msg.mode.mode != RobotMode.MODE_ACTION_COMPLETED):
+                    self.get_logger().info(f'Robot [{msg.name}] attach cart '
+                                           f'action unsuccessful, continuing '
+                                           f'with next step of the task...')
+                    completed_request = msg.mode.mode_request_id
             # Otherwise if destination is none, no ongoing process
             elif robot.destination is None:
                 return

--- a/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/fleet_manager.py
+++ b/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/fleet_manager.py
@@ -436,9 +436,11 @@ class FleetManager(Node):
                     msg.mode.mode == RobotMode.MODE_IDLE and
                     robot.perform_action_mode):
                 completed_request = msg.mode.mode_request_id
-
+            # Otherwise if destination is none, no ongoing process
+            elif robot.destination is None:
+                return
             # Check if robot has reached destination
-            if (
+            elif (
                 (
                     msg.mode.mode == RobotMode.MODE_IDLE
                     or msg.mode.mode == RobotMode.MODE_CHARGING

--- a/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/fleet_manager.py
+++ b/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/fleet_manager.py
@@ -180,15 +180,21 @@ class FleetManager(Node):
             self.dock_summary_cb,
             qos_profile=transient_qos)
 
+        publisher_qos = QoSProfile(
+            history=History.KEEP_LAST,
+            depth=10,
+            reliability=Reliability.RELIABLE,
+            durability=Durability.VOLATILE)
+
         self.path_pub = self.create_publisher(
             PathRequest,
             'robot_path_requests',
-            qos_profile=qos_profile_system_default)
+            qos_profile=publisher_qos)
 
         self.mode_pub = self.create_publisher(
             ModeRequest,
             'robot_mode_requests',
-            qos_profile=qos_profile_system_default)
+            qos_profile=publisher_qos)
 
         @app.get('/open-rmf/rmf_demos_fm/status/',
                  response_model=Response)

--- a/rmf_demos_tasks/rmf_demos_tasks/dispatch_cart_delivery.py
+++ b/rmf_demos_tasks/rmf_demos_tasks/dispatch_cart_delivery.py
@@ -101,8 +101,11 @@ class TaskRequester(Node):
                                   use_tool_sink=False):
             return {
                     "unix_millis_action_duration_estimate": duration_ms,
-                    "category": action_category,
-                    "description": {},
+                    "category": action_category,  # used to check performable action by fleet update handle
+                    "description":
+                    {
+                        "deliver_cart_task_name": action_category  # used to pass on to fleet manager to start process
+                    },
                     "use_tool_sink": use_tool_sink
                     }
 

--- a/rmf_demos_tasks/rmf_demos_tasks/dispatch_cart_delivery.py
+++ b/rmf_demos_tasks/rmf_demos_tasks/dispatch_cart_delivery.py
@@ -98,13 +98,16 @@ class TaskRequester(Node):
 
         # TODO(luca) expose duration and tool sink to CLI
         def __create_perform_action(action_category, duration_ms=10000,
-                                  use_tool_sink=False):
+                                    use_tool_sink=False):
             return {
                     "unix_millis_action_duration_estimate": duration_ms,
-                    "category": action_category,  # used to check performable action by fleet update handle
+                    # for internal FleetUpdateHandle to check if action
+                    # is performable by this fleet
+                    "category": action_category,
                     "description":
                     {
-                        "deliver_cart_task_name": action_category  # used to pass on to fleet manager to start process
+                        # for fleet manager to start action process
+                        "deliver_cart_task_name": action_category
                     },
                     "use_tool_sink": use_tool_sink
                     }

--- a/rmf_demos_tasks/rmf_demos_tasks/dispatch_clean.py
+++ b/rmf_demos_tasks/rmf_demos_tasks/dispatch_clean.py
@@ -115,7 +115,7 @@ class TaskRequester(Node):
                 "category": "clean",
                 "description":
                 {
-                    "task_name": self.args.clean_start
+                    "clean_task_name": self.args.clean_start
                 },
                 "use_tool_sink": True
             }

--- a/rmf_demos_tasks/setup.py
+++ b/rmf_demos_tasks/setup.py
@@ -29,7 +29,8 @@ setup(
           'dispatch_action = rmf_demos_tasks.dispatch_action:main',
           'dispatch_patrol = rmf_demos_tasks.dispatch_patrol:main',
           'dispatch_delivery = rmf_demos_tasks.dispatch_delivery:main',
-          'dispatch_cart_delivery = rmf_demos_tasks.dispatch_cart_delivery:main',
+          'dispatch_cart_delivery = '
+            'rmf_demos_tasks.dispatch_cart_delivery:main',
           'dispatch_clean = rmf_demos_tasks.dispatch_clean:main',
           'dispatch_go_to_place = rmf_demos_tasks.dispatch_go_to_place:main',
           'mock_docker = rmf_demos_tasks.mock_docker:main',


### PR DESCRIPTION
Reverted some of the changes for expanding action_description that extracts both `category` and `description`. `description` is empty for the current dispatch_cart_delivery definition, i updated that to follow the original perform clean action definition.

Instead of the fleet manager checking for `attach_cart` and `detach_cart` then returning the response, i thought we could categorize `start_process` tasks into (1) anything with waypoints retrievable from config.yaml/dock summary (particularly dock and clean for now) and (2) perform action tasks that don't require any waypoints, then any new actions we have can be slotted in there. Same with checking for completed_request.

Related branches:
- rmf_simulation [temp/attach_cart_with_open_door](https://github.com/open-rmf/rmf_simulation/tree/temp/attach_cart_with_open_door)
- rmf_internal_msgs [xiyu/attach_cart_action](https://github.com/open-rmf/rmf_internal_msgs/tree/xiyu/attach_cart_action)