### PR TITLE
Fix conversion from minutes to milliseconds in rmf_demos_panel

### DIFF
--- a/rmf_demos_panel/rmf_demos_panel/dispatcher_client.py
+++ b/rmf_demos_panel/rmf_demos_panel/dispatcher_client.py
@@ -320,7 +320,7 @@ class DispatcherClient(Node):
             rclpy.spin_once(self, timeout_sec=0.0)
             rostime_now = self.get_clock().now()
             unix_milli_time = round(rostime_now.nanoseconds/1e6)
-            unix_milli_time += int(task_json["start_time"]*60)
+            unix_milli_time += int(task_json["start_time"]*60*1000)
             request["unix_millis_earliest_start_time"] = unix_milli_time
         except KeyError as ex:
             return None, f"Missing Key value in json body: {ex}"


### PR DESCRIPTION
It was brought to our attention that the conversion from the old `rmf_demos_panel` format to the new `rmf_api_msgs` format had an error where minutes were not being correctly converted into milliseconds (instead they were being converted into seconds).

This PR fixes that, which is important for backwards compatibility of the `rmf_demos_panel`.