### PR TITLE
All to be downloaded using http and stored in .gazebo/models

### DIFF
--- a/rmf_demos_maps/CMakeLists.txt
+++ b/rmf_demos_maps/CMakeLists.txt
@@ -38,21 +38,12 @@ foreach(path ${traffic_editor_paths})
     )
   else()
     message("DOWNLOADING MODELS WITH COMMAND: ros2 run rmf_building_map_tools building_map_model_downloader ${map_path}")
-    if(DEFINED ENV{RMF_DOWNLOAD_MODELS_HOME})
-      add_custom_command(
-        DEPENDS ${map_path}
-        COMMAND ros2 run rmf_building_map_tools building_map_generator gazebo ${map_path} ${output_world_path} ${output_model_dir}
-        COMMAND ros2 run rmf_building_map_tools building_map_model_downloader ${map_path} -f -e ~/.gazebo/models
-        OUTPUT ${output_world_path}
-      )
-    else()
-      add_custom_command(
-        DEPENDS ${map_path}
-        COMMAND ros2 run rmf_building_map_tools building_map_generator gazebo ${map_path} ${output_world_path} ${output_model_dir}
-        COMMAND ros2 run rmf_building_map_tools building_map_model_downloader ${map_path} -f -e ${output_model_dir}
-        OUTPUT ${output_world_path}
-      )
-    endif()
+    add_custom_command(
+      DEPENDS ${map_path}
+      COMMAND ros2 run rmf_building_map_tools building_map_generator gazebo ${map_path} ${output_world_path} ${output_model_dir}
+      COMMAND ros2 run rmf_building_map_tools building_map_model_downloader ${map_path} -e ~/.gazebo/models
+      OUTPUT ${output_world_path}
+    )
   endif()
 
   ##############################################################################
@@ -68,7 +59,7 @@ foreach(path ${traffic_editor_paths})
   # This will initiate both custom commands: ${output_world_path} and ${world_name}_crowdsim
   add_custom_target(generate_${world_name}_crowdsim ALL
     DEPENDS ${world_name}_crowdsim
-  )  
+  )
 
   ##############################################################################
   ## Ign worlds


### PR DESCRIPTION
<!--
For support requests, please read the Support Guidelines to know where to ask: https://github.com/open-rmf/rmf/wiki/Support-guidelines
For general questions and design discussion, please use the Discussions page: https://github.com/open-rmf/rmf/discussions
Not sure if this is the right repository? Open an issue on https://github.com/open-rmf/rmf
We require contributors to GPG Sign their commits. Follow the guide here to set up a GPG key and add it to your GitHub account: https://docs.github.com/en/github/authenticating-to-github/generating-a-new-gpg-key
A quick guide to how to sign your commits can be seen here: https://gist.github.com/mort3za/ad545d47dd2b54970c102fe39912f305
To GPG sign several commits at once (for example, if you forgot to sign some commits), you can run this command, followed by a force-push: git rebase --exec 'git commit --amend --no-edit -n -S' -i <commit before the first commit you want signed>
For bug fix pull requests, please fill out the information below.
Be as detailed as possible.
-->

## Bug fix

### Fixed bug

<!-- Briefly describe the bug being fixed.
If there is a bug report issue for the bug, link to that issue.
If there is not a bug report issue for the bug, create one first and fill out all the required information there, then link to that issue from this bug fix pull request. -->

Fixes https://github.com/open-rmf/rmf_traffic_editor/issues/469
Requires https://github.com/open-rmf/rmf_traffic_editor/pull/470.

* Fixes the issue where `rmf_demos_gz_classic` model downloads repeatedly
* Stop exporting models into `ws/install/rmf_demos_maps`, since we do not plan to release `rmf_demos` packages as binaries any more

### Fix applied

Revert to using `http` download, as it retains the `model://` tag instead of the full Fuel url, https://github.com/gazebosim/gz-fuel-tools/issues/77#issuecomment-648548920. 
