### PR TITLE
Fix airport terminal demo

### DIFF
--- a/rmf_demos/launch/airport_terminal.launch.xml
+++ b/rmf_demos/launch/airport_terminal.launch.xml
@@ -54,9 +54,6 @@
     </include>
   </group>
 
-    <param name="use_sim_time" value="$(var use_sim_time)"/>
-  </node>
-
   <!-- cleanerBotE fleet adapter -->
   <group>
     <include file="$(find-pkg-share rmf_demos_fleet_adapter)/launch/fleet_adapter.launch.xml">


### PR DESCRIPTION
## Bug fix

### Fixed bug

As of #158, the airport terminal demo doesn't work anymore because of a malformed XML file. This PR fixes it.