### PR TITLE
Add a script for opening and closing lanes

### DIFF
--- a/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/fleet_adapter.py
+++ b/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/fleet_adapter.py
@@ -159,7 +159,7 @@ def main(argv=sys.argv):
     update_thread.start()
 
     # Connect to the extra ROS2 topics that are relevant for the adapter
-    ros_connections(node, robots, fleet_handle)
+    connections = ros_connections(node, robots, fleet_handle)
 
     # Create executor for the command handle node
     rclpy_executor = rclpy.executors.SingleThreadedExecutor()
@@ -416,11 +416,18 @@ def ros_connections(node, robots, fleet_handle):
     closed_lanes = set()
 
     def lane_request_cb(msg):
-        if msg.fleet_name is None or msg.fleet_name != fleet_name:
+        if msg.fleet_name and msg.fleet_name != fleet_name:
+            print(f'Ignoring lane request for fleet [{msg.fleet_name}]')
             return
 
-        fleet_handle.open_lanes(msg.open_lanes)
-        fleet_handle.close_lanes(msg.close_lanes)
+        if msg.open_lanes:
+            print(f'Opening lanes: {msg.open_lanes}')
+
+        if msg.close_lanes:
+            print(f'Closing lanes: {msg.close_lanes}')
+
+        fleet_handle.more().open_lanes(msg.open_lanes)
+        fleet_handle.more().close_lanes(msg.close_lanes)
 
         for lane_idx in msg.close_lanes:
             closed_lanes.add(lane_idx)
@@ -447,19 +454,24 @@ def ros_connections(node, robots, fleet_handle):
                 return
             robot.finish_action()
 
-    node.create_subscription(
+    lane_request_sub = node.create_subscription(
         LaneRequest,
         'lane_closure_requests',
         lane_request_cb,
         qos_profile=qos_profile_system_default,
     )
 
-    node.create_subscription(
+    action_execution_notice_sub = node.create_subscription(
         ModeRequest,
         'action_execution_notice',
         mode_request_cb,
         qos_profile=qos_profile_system_default,
     )
+
+    return [
+        lane_request_sub,
+        action_execution_notice_sub,
+    ]
 
 
 if __name__ == '__main__':

--- a/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/manage_lane.py
+++ b/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/manage_lane.py
@@ -1,0 +1,143 @@
+# Copyright 2024 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import rclpy
+from rclpy.duration import Duration
+import rclpy.node
+from rclpy.qos import QoSDurabilityPolicy as Durability
+from rclpy.qos import QoSHistoryPolicy as History
+from rclpy.qos import QoSProfile
+from rclpy.qos import QoSReliabilityPolicy as Reliability
+import rmf_adapter
+import rmf_adapter.vehicletraits as traits
+import rmf_adapter.geometry as geometry
+
+from rmf_fleet_msgs.msg import LaneRequest
+
+import argparse
+import threading
+import sys
+import asyncio
+
+def main(argv=sys.argv):
+    rclpy.init(args=argv)
+    args_without_ros = rclpy.utilities.remove_ros_args(argv)
+
+    parser = argparse.ArgumentParser(
+        prog='manage_lane',
+        description='Open or close a lane between two waypoints'
+    )
+    parser.add_argument(
+        'request',
+        choices=['open', 'close'],
+        help='Whether the lane should be open or closed',
+    )
+    parser.add_argument(
+        'from_waypoint',
+        type=str,
+        help='Name of the waypoint at the start of the lane',
+    )
+    parser.add_argument(
+        'to_waypoint',
+        type=str,
+        help='Name of the waypoint at the end of the lane',
+    )
+    parser.add_argument(
+        '-b',
+        '--bidir',
+        action='store_true',
+        help='Apply the state change in both directions (bidirectionally)'
+    )
+    parser.add_argument(
+        '-F',
+        '--fleet',
+        type=str,
+        default='',
+        help='Which fleet should the lane be closed for. Empty string (default) indicates all fleets.',
+    )
+    parser.add_argument(
+        '-n',
+        '--nav_graph',
+        type=str,
+        required=True,
+        help='Path to the nav_graph that contains the lane',
+    )
+
+    args = parser.parse_args(args_without_ros[1:])
+
+    t = traits.VehicleTraits(
+        linear=traits.Limits(1.0, 1.0),
+        angular=traits.Limits(1.0, 1.0),
+        profile=traits.Profile(geometry.make_final_convex_circle(1.0)),
+    )
+
+    nav_graph = rmf_adapter.graph.parse_graph(args.nav_graph, t)
+
+    from_waypoint = nav_graph.find_waypoint(args.from_waypoint)
+    if from_waypoint is None:
+        raise Exception(f'Unable to find waypoint [{args.from_waypoint}] in graph')
+
+    to_waypoint = nav_graph.find_waypoint(args.to_waypoint)
+    if to_waypoint is None:
+        raise Exception(f'Unable to find waypoint [{args.to_waypoint}] in graph')
+
+    lane_indices = []
+
+    lane = nav_graph.lane_from(from_waypoint.index, to_waypoint.index)
+    if lane is None:
+        raise Exception(f'Unable to find a lane that connects [{args.from_waypoint}] to [{args.to_waypoint}]')
+
+    lane_indices.append(lane.index)
+
+    if args.bidir:
+        reverse_lane = nav_graph.lane_from(to_waypoint.index, from_waypoint.index)
+        if reverse_lane is not None:
+            lane_indices.append(reverse_lane.index)
+
+    request = LaneRequest()
+    if args.request == 'open':
+        request.open_lanes = lane_indices
+    if args.request == 'close':
+        request.close_lanes = lane_indices
+    request.fleet_name = args.fleet
+
+    node = rclpy.node.Node(f'manage_lane')
+
+    transient_qos = QoSProfile(
+        history=History.KEEP_LAST,
+        depth=1,
+        reliability=Reliability.RELIABLE,
+        durability=Durability.TRANSIENT_LOCAL,
+    )
+
+    publisher = node.create_publisher(
+        LaneRequest,
+        'lane_closure_requests',
+        qos_profile=transient_qos,
+    )
+
+    publisher.publish(request)
+
+    rclpy_executor = rclpy.executors.SingleThreadedExecutor()
+    rclpy_executor.add_node(node)
+
+    print(f'Sending request:\n{request}')
+
+    f = asyncio.Future()
+    rclpy_executor.spin_until_future_complete(f, 5.0)
+    # TODO(@mxgrey): Subscribe to lane closure topic and keep spinning until
+    # we see these lanes open/closed
+
+if __name__ == '__main__':
+    main(sys.argv)

--- a/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/manage_lane.py
+++ b/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/manage_lane.py
@@ -30,6 +30,7 @@ import threading
 import sys
 import asyncio
 
+
 def main(argv=sys.argv):
     rclpy.init(args=argv)
     args_without_ros = rclpy.utilities.remove_ros_args(argv)
@@ -64,7 +65,10 @@ def main(argv=sys.argv):
         '--fleet',
         type=str,
         default='',
-        help='Which fleet should the lane be closed for. Empty string (default) indicates all fleets.',
+        help=(
+            'Which fleet should the lane be closed for. '
+            'Empty string (default) indicates all fleets.'
+        ),
     )
     parser.add_argument(
         '-n',
@@ -86,22 +90,31 @@ def main(argv=sys.argv):
 
     from_waypoint = nav_graph.find_waypoint(args.from_waypoint)
     if from_waypoint is None:
-        raise Exception(f'Unable to find waypoint [{args.from_waypoint}] in graph')
+        raise Exception(
+            f'Unable to find waypoint [{args.from_waypoint}] in graph'
+        )
 
     to_waypoint = nav_graph.find_waypoint(args.to_waypoint)
     if to_waypoint is None:
-        raise Exception(f'Unable to find waypoint [{args.to_waypoint}] in graph')
+        raise Exception(
+            f'Unable to find waypoint [{args.to_waypoint}] in graph'
+        )
 
     lane_indices = []
 
     lane = nav_graph.lane_from(from_waypoint.index, to_waypoint.index)
     if lane is None:
-        raise Exception(f'Unable to find a lane that connects [{args.from_waypoint}] to [{args.to_waypoint}]')
+        raise Exception(
+            f'Unable to find a lane that connects [{args.from_waypoint}] '
+            f'to [{args.to_waypoint}]'
+        )
 
     lane_indices.append(lane.index)
 
     if args.bidir:
-        reverse_lane = nav_graph.lane_from(to_waypoint.index, from_waypoint.index)
+        reverse_lane = nav_graph.lane_from(
+            to_waypoint.index, from_waypoint.index
+        )
         if reverse_lane is not None:
             lane_indices.append(reverse_lane.index)
 
@@ -138,6 +151,7 @@ def main(argv=sys.argv):
     rclpy_executor.spin_until_future_complete(f, 5.0)
     # TODO(@mxgrey): Subscribe to lane closure topic and keep spinning until
     # we see these lanes open/closed
+
 
 if __name__ == '__main__':
     main(sys.argv)

--- a/rmf_demos_fleet_adapter/setup.py
+++ b/rmf_demos_fleet_adapter/setup.py
@@ -34,6 +34,7 @@ setup(
         'console_scripts': [
             'fleet_adapter=rmf_demos_fleet_adapter.fleet_adapter:main',
             'fleet_manager=rmf_demos_fleet_adapter.fleet_manager:main',
+            'manage_lane=rmf_demos_fleet_adapter.manage_lane:main',
         ],
     },
 )

--- a/rmf_demos_maps/maps/office/office.building.yaml
+++ b/rmf_demos_maps/maps/office/office.building.yaml
@@ -238,7 +238,7 @@ levels:
       - [612.96900000000005, 445.58999999999997, 0, ""]
       - [933.08600000000001, 744.67600000000004, 0, ""]
       - [657.60599999999999, 1282.1559999999999, 0, ""]
-      - [830.92200000000003, 249.364, 0, "", {is_parking_spot: [4, false]}]
+      - [830.92200000000003, 249.364, 0, presupplies, {is_parking_spot: [4, false]}]
       - [1210.5440000000001, 365.25400000000002, 0, patrol_D2]
       - [1191.442, 824.45699999999999, 0, patrol_A1]
       - [1232.421, 658.56700000000001, 0, tinyRobot1_charger, {is_charger: [4, true], is_holding_point: [4, true], is_parking_spot: [4, true], spawn_robot_name: [1, tinyRobot1], spawn_robot_type: [1, TinyRobot]}]


### PR DESCRIPTION
This adds a `manage_lane` executable script to the `rmf_demos_fleet_adapter` package that allows users to command a lane open or closed from the command line, applicable to the fleet adapter provided in `rmf_demos_fleet_adapter`.