### PR TITLE
Fix office dispenser height to be on top of furniture

### DIFF
--- a/rmf_demos_maps/maps/office/office.building.yaml
+++ b/rmf_demos_maps/maps/office/office.building.yaml
@@ -164,9 +164,9 @@ levels:
       - {dispensable: false, model_name: OpenRobotics/ConfTable, name: ConfTable, static: true, x: 620, y: 872, yaw: 1.1016999999999999, z: 0}
       - {dispensable: false, model_name: OpenRobotics/WhiteCabinet, name: WhiteCabinet, static: true, x: 1775.8789999999999, y: 344.82299999999998, yaw: -0.035700000000000003, z: 0}
       - {dispensable: false, model_name: OpenRobotics/SquareShelf, name: SquareShelf, static: true, x: 938.97000000000003, y: 352.11799999999999, yaw: 2.6640000000000001, z: 0}
-      - {dispensable: false, model_name: OpenRobotics/TeleportDispenser, name: coke_dispenser, static: true, x: 2097.3649999999998, y: 649.80899999999997, yaw: 1.5708, z: 2}
-      - {dispensable: false, model_name: OpenRobotics/TeleportDispenser, name: coke_dispenser_2, static: true, x: 2095.2669999999998, y: 689.745, yaw: 1.5708, z: 1}
-      - {dispensable: false, model_name: OpenRobotics/Coke, name: Coke, static: false, x: 2098.6509999999998, y: 650.52300000000002, yaw: 1.5708, z: 2}
+      - {dispensable: false, model_name: OpenRobotics/TeleportDispenser, name: coke_dispenser, static: true, x: 2097.3649999999998, y: 649.80899999999997, yaw: 1.5708, z: 1.0800000000000001}
+      - {dispensable: false, model_name: OpenRobotics/TeleportDispenser, name: coke_dispenser_2, static: true, x: 2095.2669999999998, y: 689.745, yaw: 1.5708, z: 0.63}
+      - {dispensable: false, model_name: OpenRobotics/Coke, name: Coke, static: false, x: 2098.6509999999998, y: 650.52300000000002, yaw: 1.5708, z: 1.0800000000000001}
       - {dispensable: false, model_name: OpenRobotics/TeleportIngestor, name: coke_ingestor, static: true, x: 2662.8870000000002, y: 898.99599999999998, yaw: 1.5708, z: 0.80500000000000005}
       - {dispensable: false, model_name: OpenRobotics/TeleportIngestor, name: coke_ingestor_2, static: true, x: 668.75900000000001, y: 703.86400000000003, yaw: 1.5708, z: 0.80000000000000004}
       - {dispensable: false, model_name: OpenRobotics/MetalCabinet, name: OpenRobotics/MetalCabinet, static: true, x: 1946.0540000000001, y: 1238.8910000000001, yaw: 0.0092999999999999992, z: 0}


### PR DESCRIPTION
## Bug fix

This PR reduces the height of the dispenser and Coke can to be on top of the shelves. Before they were at a height of 1 meter and 2 meters which made the items float.
Attaching screenshots below to show the new measurements:

![Screenshot from 2024-03-18 18-06-27](https://github.com/open-rmf/rmf_demos/assets/9111558/aeb93667-44dd-4be6-bd21-4f6cb1d49fe4)

![Screenshot from 2024-03-18 18-06-23](https://github.com/open-rmf/rmf_demos/assets/9111558/ffd46132-27bb-475a-ac45-f26cebe5f75a)
