### PR TITLE
Corrected the way open_lanes and close_lanes functions are called

### DIFF
--- a/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/fleet_adapter.py
+++ b/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/fleet_adapter.py
@@ -419,8 +419,8 @@ def ros_connections(node, robots, fleet_handle):
         if msg.fleet_name is None or msg.fleet_name != fleet_name:
             return
 
-        fleet_handle.open_lanes(msg.open_lanes)
-        fleet_handle.close_lanes(msg.close_lanes)
+        fleet_handle.more().open_lanes(msg.open_lanes)
+        fleet_handle.more().close_lanes(msg.close_lanes)
 
         for lane_idx in msg.close_lanes:
             closed_lanes.add(lane_idx)


### PR DESCRIPTION
Signed-off-by: Suchetan R S <rssuchetan@gmail.com>

This PR corrects the way the open_lanes and close_lanes functions are called. Lane closure works properly post this change. Related issue for this PR is [here](https://github.com/open-rmf/rmf_demos/issues/221).