### PR TITLE
Add task reassignment trigger in update loop

### DIFF
--- a/rmf_demos/config/office/tinyRobot_config.yaml
+++ b/rmf_demos/config/office/tinyRobot_config.yaml
@@ -32,6 +32,7 @@ rmf_fleet:
   actions: ["teleop"]
   finishing_request: "park" # [park, charge, nothing]
   responsive_wait: True # Should responsive wait be on/off for the whole fleet by default? False if not specified.
+  reassign_task_interval: 120 # seconds, specify how often a task reassignment should be triggered in the fleet
   robots:
     tinyRobot1:
         charger: "tinyRobot1_charger"

--- a/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/fleet_adapter.py
+++ b/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/fleet_adapter.py
@@ -138,8 +138,8 @@ def main(argv=sys.argv):
         )
 
     def update_loop():
-        reassign_task_interval = \
-            config_yaml['rmf_fleet'].get('reassign_task_interval', 60) # seconds
+        reassign_task_interval = config_yaml['rmf_fleet'].get(
+            'reassign_task_interval', 60)  # seconds
         last_task_replan = node.get_clock().now()
         asyncio.set_event_loop(asyncio.new_event_loop())
         while rclpy.ok():


### PR DESCRIPTION
This PR demonstrates how we can use the `reassign_dispatched_tasks` API available from https://github.com/open-rmf/rmf_ros2/pull/348. The frequency to trigger this reassignment can be configured inside the fleet config.