### PR TITLE
added methods in fleet adapter and RobotCommandHandle to read and use parking waypoint

### DIFF
--- a/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/RobotCommandHandle.py
+++ b/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/RobotCommandHandle.py
@@ -69,6 +69,7 @@ class RobotCommandHandle(adpt.RobotCommandHandle):
                  start,
                  position,
                  charger_waypoint,
+                 parking_waypoint,
                  update_frequency,
                  lane_merge_distance,
                  adapter,
@@ -87,6 +88,11 @@ class RobotCommandHandle(adpt.RobotCommandHandle):
         assert waypoint, f"Charger waypoint {charger_waypoint} \
           does not exist in the navigation graph"
         self.charger_waypoint_index = waypoint.index
+        # Get the index of the parking spot waypoint
+        waypoint = self.graph.find_waypoint(parking_waypoint)
+        assert waypoint, f"Parking waypoint {parking_waypoint} \
+          does not exist in the navigation graph"
+        self.parking_waypoint_index = waypoint.index
         self.update_frequency = update_frequency
         self.lane_merge_distance = lane_merge_distance
         self.update_handle = None  # RobotUpdateHandle

--- a/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/fleet_adapter.py
+++ b/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/fleet_adapter.py
@@ -195,6 +195,14 @@ def initialize_fleet(config_yaml, nav_graph_path, node, use_sim_time):
             cmd_handle.node.get_logger().warn(
                 "Invalid waypoint supplied for charger. "
                 "Using default nearest charger in the map")
+        if (cmd_handle.parking_waypoint_index <
+                cmd_handle.graph.num_waypoints):
+            cmd_handle.update_handle.set_parking_waypoint(
+                cmd_handle.parking_waypoint_index)
+        else:
+            cmd_handle.node.get_logger().warn(
+                "Invalid waypoint supplied for parking spot. "
+                "Using default nearest parking spot in the map")
 
     # Initialize robot API for this fleet
     prefix = 'http://' + fleet_config['fleet_manager']['ip'] + \
@@ -277,6 +285,7 @@ def initialize_fleet(config_yaml, nav_graph_path, node, use_sim_time):
                         start=starts[0],
                         position=position,
                         charger_waypoint=rmf_config['charger']['waypoint'],
+                        parking_waypoint=rmf_config['start']['waypoint'],
                         update_frequency=rmf_config.get(
                             'robot_state_update_frequency', 1),
                         lane_merge_distance=lane_merge_distance,


### PR DESCRIPTION
## Bug fix

### Fixed bug

Currently if we set the parking waypoint of a robot to a waypoint that is not a charger, and configure the finishing request as "park", the robot will still go back to its charger, instead of its parking spot, after finishing a task. This bug is raised in issue https://github.com/open-rmf/rmf_demos/issues/219 and https://github.com/open-rmf/rmf_task/issues/115.


### Fix applied

This issue happens because when we generate a parking request for the robot, we did not pass in a parking spot waypoint, and therefore the robot will head to its charger as default. My approach is the similar as suggested by Yadunund in https://github.com/open-rmf/rmf_task/issues/115 (the only difference is because I am on the humble branch instead of the main branch).

Basically, the Fleet adapter will read the dedicated parking waypoint for each robot from the configuration file, pass that waypoint to RobotCommandHandle and RobotUpdateHandle so that this waypoint will be set as the dedicated parking waypoint for each robot. When sending requests to robots, fleet adapter needs to know each robot's State, which can be retrieved through RobotContext. The robots' current state with a dedicated parking waypoint will be sent back to the fleet adapter. When creating finishing request, if the finishing request is configured as "park", fleet adapter will call the ParkRobotFactory class to use that parking waypoint as a finishing waypoint.

To implement the fix, I need to make changes to three repos: rmf_demos, rmf_task, and rmf_ros2. And therefore I have three pull requests. Please review them together. 


