### PR TITLE
Adding server_uri for dispatcher node

### DIFF
--- a/rmf_demos/launch/common.launch.xml
+++ b/rmf_demos/launch/common.launch.xml
@@ -11,6 +11,7 @@
   <arg name="bidding_time_window" description="Time window in seconds for task bidding process" default="2.0"/>
   <arg name="use_rmf_panel" default="true" description="launch web and api server for rmf_demos_panel"/>
   <arg name="use_unique_hex_string_with_task_id" default="true" description="Appends a unique hex string to the task ID"/>
+  <arg name="server_uri" default="ws://localhost:8000/_internal" description="The URI of the api server to transmit state and task information"/>
 
   <!-- Traffic Schedule  -->
   <node pkg="rmf_traffic_ros2" exec="rmf_traffic_schedule" output="both" name="rmf_traffic_schedule_primary">
@@ -59,6 +60,7 @@
       <param name="use_sim_time" value="$(var use_sim_time)"/>
       <param name="bidding_time_window" value="$(var bidding_time_window)"/>
       <param name="use_unique_hex_string_with_task_id" value="$(var use_unique_hex_string_with_task_id)"/>
+      <param name="server_uri" value="$(var server_uri)"/>
     </node>
   </group>
 


### PR DESCRIPTION
## New feature implementation

### Implemented feature

Related to https://github.com/open-rmf/rmf_ros2/pull/355.
Gives the dispatcher node websocket access to servers