### PR TITLE
Use same empty string default value as fleet adapter launches

### DIFF
--- a/rmf_demos/launch/common.launch.xml
+++ b/rmf_demos/launch/common.launch.xml
@@ -11,7 +11,7 @@
   <arg name="bidding_time_window" description="Time window in seconds for task bidding process" default="2.0"/>
   <arg name="use_rmf_panel" default="true" description="launch web and api server for rmf_demos_panel"/>
   <arg name="use_unique_hex_string_with_task_id" default="true" description="Appends a unique hex string to the task ID"/>
-  <arg name="server_uri" default="ws://localhost:8000/_internal" description="The URI of the api server to transmit state and task information"/>
+  <arg name="server_uri" default="" description="The URI of the api server to transmit state and task information."/>
 
   <!-- Traffic Schedule  -->
   <node pkg="rmf_traffic_ros2" exec="rmf_traffic_schedule" output="both" name="rmf_traffic_schedule_primary">


### PR DESCRIPTION
## Bug fix

### Fixed bug

Fix issue mentioned in https://github.com/open-rmf/rmf_demos/pull/230, which causes undesired logging when server URI is not found by using same empty string default vaue as fleet adapter launches