### PR TITLE
Addresses #250: Fixes undefined variable in `FleetManager`

### DIFF
--- a/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/fleet_manager.py
+++ b/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/fleet_manager.py
@@ -347,7 +347,7 @@ class FleetManager(Node):
                 return response
 
             # Invalid request
-            if (robot_name not in self.robots or len(task.task) < 1):
+            if robot_name not in self.robots:
                 return response
             robot = self.robots[robot_name]
 


### PR DESCRIPTION
Thanks  @techmanjeet for spotting this issue. I can confirm that this
issue is an issue. Seems like we dont define `task` anymore.

