### PR TITLE
Fixed mode_request_cb() when missing robot_name/fleet_name and changed print() into node.get_logger().

### DIFF
--- a/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/RobotCommandHandle.py
+++ b/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/RobotCommandHandle.py
@@ -722,7 +722,7 @@ class RobotCommandHandle(adpt.RobotCommandHandle):
 
     def mode_request_cb(self, msg):
         if not msg.fleet_name or msg.fleet_name != self.fleet_name or\
-                not msg.robot_name:
+                not msg.robot_name or msg.robot_name != self.name:
             return
         if msg.mode.mode == RobotState.IDLE:
             self.complete_robot_action()

--- a/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/RobotCommandHandle.py
+++ b/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/RobotCommandHandle.py
@@ -721,8 +721,8 @@ class RobotCommandHandle(adpt.RobotCommandHandle):
                     self.docks[dock.start] = dock.path
 
     def mode_request_cb(self, msg):
-        if msg.fleet_name is None or msg.fleet_name != self.fleet_name or\
-                msg.robot_name is None:
+        if not msg.fleet_name or msg.fleet_name != self.fleet_name or\
+                not msg.robot_name:
             return
         if msg.mode.mode == RobotState.IDLE:
             self.complete_robot_action()

--- a/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/RobotCommandHandle.py
+++ b/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/RobotCommandHandle.py
@@ -169,7 +169,7 @@ class RobotCommandHandle(adpt.RobotCommandHandle):
     def next_cmd_id(self):
         self.current_cmd_id = self.current_cmd_id + 1
         if self.debug:
-            print(f'Issuing cmd_id for {self.name}: {self.current_cmd_id}')
+            self.node.get_logger().info(f'Issuing cmd_id for {self.name}: {self.current_cmd_id}')
         return self.current_cmd_id
 
     def sleep_for(self, seconds):
@@ -194,7 +194,7 @@ class RobotCommandHandle(adpt.RobotCommandHandle):
 
     def interrupt(self):
         if self.debug:
-            print(
+            self.node.get_logger().info(
                 f'Interrupting {self.name} '
                 f'(latest cmd_id is {self.current_cmd_id})'
             )
@@ -217,7 +217,7 @@ class RobotCommandHandle(adpt.RobotCommandHandle):
     def stop(self):
         if self.debug:
             plan_id = self.update_handle.unstable_current_plan_id()
-            print(f'stop for {self.name} with PlanId {plan_id}')
+            self.node.get_logger().info(f'stop for {self.name} with PlanId {plan_id}')
 
         self.interrupt()
         # Stop the robot. Tracking variables should remain unchanged.
@@ -256,7 +256,7 @@ class RobotCommandHandle(adpt.RobotCommandHandle):
             path_finished_callback):
         if self.debug:
             plan_id = self.update_handle.unstable_current_plan_id()
-            print(f'follow_new_path for {self.name} with PlanId {plan_id}')
+            self.node.get_logger().info(f'follow_new_path for {self.name} with PlanId {plan_id}')
         self.interrupt()
         with self._lock:
             self._follow_path_thread = None

--- a/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/RobotCommandHandle.py
+++ b/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/RobotCommandHandle.py
@@ -169,7 +169,7 @@ class RobotCommandHandle(adpt.RobotCommandHandle):
     def next_cmd_id(self):
         self.current_cmd_id = self.current_cmd_id + 1
         if self.debug:
-            self.node.get_logger().info(f'Issuing cmd_id for {self.name}: {self.current_cmd_id}')
+            print(f'Issuing cmd_id for {self.name}: {self.current_cmd_id}')
         return self.current_cmd_id
 
     def sleep_for(self, seconds):
@@ -194,7 +194,7 @@ class RobotCommandHandle(adpt.RobotCommandHandle):
 
     def interrupt(self):
         if self.debug:
-            self.node.get_logger().info(
+            print(
                 f'Interrupting {self.name} '
                 f'(latest cmd_id is {self.current_cmd_id})'
             )
@@ -217,7 +217,7 @@ class RobotCommandHandle(adpt.RobotCommandHandle):
     def stop(self):
         if self.debug:
             plan_id = self.update_handle.unstable_current_plan_id()
-            self.node.get_logger().info(f'stop for {self.name} with PlanId {plan_id}')
+            print(f'stop for {self.name} with PlanId {plan_id}')
 
         self.interrupt()
         # Stop the robot. Tracking variables should remain unchanged.
@@ -256,7 +256,7 @@ class RobotCommandHandle(adpt.RobotCommandHandle):
             path_finished_callback):
         if self.debug:
             plan_id = self.update_handle.unstable_current_plan_id()
-            self.node.get_logger().info(f'follow_new_path for {self.name} with PlanId {plan_id}')
+            print(f'follow_new_path for {self.name} with PlanId {plan_id}')
         self.interrupt()
         with self._lock:
             self._follow_path_thread = None


### PR DESCRIPTION
## Bug fix

### Fixed bug

#253 

### Fix applied

In the RobotCommandHandle.py, `mode_request_cb()` is the callback of the subscriber to the topic `/action_execution_notice`.

This cb function is supposed to check if the fleet_name or robot_name have a value.
However, in python 2 and python3, this verification is done with the `not ...` operation.

This PR fixes the if() condition in `mode_request_cb()`, as accordingly to the python2 and python3, considering the fields as Boolean variables.