### PR TITLE
Use environment hooks for plugins / assets

### DIFF
--- a/rmf_demos_assets/CMakeLists.txt
+++ b/rmf_demos_assets/CMakeLists.txt
@@ -4,6 +4,8 @@ project(rmf_demos_assets)
 
 find_package(ament_cmake REQUIRED)
 
+ament_environment_hooks("${CMAKE_CURRENT_SOURCE_DIR}/hooks/${PROJECT_NAME}.dsv.in")
+
 install(
   DIRECTORY models
   DESTINATION share/${PROJECT_NAME}

--- a/rmf_demos_assets/hooks/rmf_demos_assets.dsv.in
+++ b/rmf_demos_assets/hooks/rmf_demos_assets.dsv.in
@@ -1,0 +1,1 @@
+prepend-non-duplicate;GZ_SIM_RESOURCE_PATH;share/rmf_demos_assets/models

--- a/rmf_demos_gz/launch/simulation.launch.xml
+++ b/rmf_demos_gz/launch/simulation.launch.xml
@@ -7,8 +7,7 @@
   <arg name="gazebo_version" default='8'/>
 
   <let name="world_path" value="$(find-pkg-share $(var map_package))/maps/$(var map_name)/$(var map_name).world" />
-  <let name="model_path" value="$(find-pkg-share $(var map_package))/maps/$(var map_name)/models:$(find-pkg-share $(var map_package))/maps/$(var map_name)/models:$(find-pkg-share rmf_demos_assets)/models:$(env HOME)/.gazebo/models" />
-  <let name="plugin_path" value="$(find-pkg-prefix rmf_robot_sim_gz_plugins)/lib/rmf_robot_sim_gz_plugins:$(find-pkg-prefix rmf_building_sim_gz_plugins)/lib/rmf_building_sim_gz_plugins" />
+  <let name="model_path" value="$(find-pkg-share $(var map_package))/maps/$(var map_name)/models:$(env HOME)/.gazebo/models" />
 
   <!-- Use crowd sim if `use_crowdsim` is true-->
   <let name="menge_resource_path" if="$(var use_crowdsim)" value="$(find-pkg-share $(var map_package))/maps/$(var map_name)/config_resource"/>
@@ -17,10 +16,9 @@
   <let name="gz_headless" if="$(var headless)" value="-s"/>
   <let name="gz_headless" unless="$(var headless)" value="" />
 
+  <!-- TODO(luca) Remove the manual concatenation of GZ_SIM_RESOURCE_PATH and just use environment hooks -->
   <executable cmd="gz sim --force-version $(var gazebo_version) $(var gz_headless) -r -v 3 $(var world_path)" output="both">
-    <env name="GZ_SIM_RESOURCE_PATH" value="$(var model_path):$(var world_path)" />
-    <env name="GZ_SIM_SYSTEM_PLUGIN_PATH" value="$(var plugin_path)"/>
-    <env name="GZ_GUI_PLUGIN_PATH" value="$(var plugin_path)"/>
+    <env name="GZ_SIM_RESOURCE_PATH" value="$(env GZ_SIM_RESOURCE_PATH):$(var model_path)" />
     <env name="MENGE_RESOURCE_PATH" value="$(var menge_resource_path)"/>
   </executable>
 


### PR DESCRIPTION
## New feature implementation

### Implemented feature

Use environment hooks instead of manually creating environment variables for launching gazebo simulations.

### Implementation description

Needs https://github.com/open-rmf/rmf_simulation/pull/136.
Brings us 90% of the way there to only using hooks for setting variables (the remaining TODO is not fully straightforward and might require changes on `rmf_traffic_editor` so left it for now, more explanation below).
Both plugins (with upstream `rmf_simulation` PR) and rmf_demos_assets (with this PR) will set environment variables to make lookups easier.
This reduces boilerplate on the launch file and also makes it easier for third parties to use these packages without having to manually set their environment variables.


There is a remaining TODO because for each map we add to the path:

```
(find-pkg-share $(var map_package))/maps/$(var map_name)/models
```

This makes it possible for the root level world file to be able to lookup the level meshes that come in the format (example from office world):

```
<include>
  <name>building_L1</name>
  <uri>model://building_L1</uri>
  <pose>0 0 0.0 0 0 0</pose>
</include>
```

However, if we want this to work with hooks and, for example, add `find-pkg-share $(var map_package))/maps` to an environment hook, the `uri` should change to the subfolder which doesn't quite look as clean. I'm also not 100% sure it would be able to find its submeshes:

```
<uri>model://office/models/building_L1</uri>
```

For this reason I left this as a TODO, I also left the `.gazebo/models` here since it's probably not a good idea to add that to the path of users when our packages are built