### PR TITLE
only remove lane_idx if exist in closed_lanes

### DIFF
--- a/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/fleet_adapter.py
+++ b/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/fleet_adapter.py
@@ -456,7 +456,8 @@ def ros_connections(node, robots, fleet_handle):
             closed_lanes.add(lane_idx)
 
         for lane_idx in msg.open_lanes:
-            closed_lanes.remove(lane_idx)
+            if lane_idx in closed_lanes:
+                closed_lanes.remove(lane_idx)
 
         state_msg = ClosedLanes()
         state_msg.fleet_name = fleet_name


### PR DESCRIPTION
<!--
For support requests, please read the Support Guidelines to know where to ask: https://github.com/open-rmf/rmf/wiki/Support-guidelines
For general questions and design discussion, please use the Discussions page: https://github.com/open-rmf/rmf/discussions
Not sure if this is the right repository? Open an issue on https://github.com/open-rmf/rmf
We require contributors to GPG Sign their commits. Follow the guide here to set up a GPG key and add it to your GitHub account: https://docs.github.com/en/github/authenticating-to-github/generating-a-new-gpg-key
A quick guide to how to sign your commits can be seen here: https://gist.github.com/mort3za/ad545d47dd2b54970c102fe39912f305
To GPG sign several commits at once (for example, if you forgot to sign some commits), you can run this command, followed by a force-push: git rebase --exec 'git commit --amend --no-edit -n -S' -i <commit before the first commit you want signed>
For bug fix pull requests, please fill out the information below.
Be as detailed as possible.
-->

## Bug fix

### Fixed bug

<!-- Briefly describe the bug being fixed.
If there is a bug report issue for the bug, link to that issue.
If there is not a bug report issue for the bug, create one first and fill out all the required information there, then link to that issue from this bug fix pull request. -->

If `lane_idx` not in `closed_lanes`, it would show below error:

```
[fleet_adapter-14] Traceback (most recent call last):
[fleet_adapter-14]   File "/home/will/humble_harmonic/rmf_ws/install/rmf_demos_fleet_adapter/lib/rmf_demos_fleet_adapter/fleet_adapter", line 33, in <module>
[fleet_adapter-14]     sys.exit(load_entry_point('rmf-demos-fleet-adapter==2.5.0', 'console_scripts', 'fleet_adapter')())
[fleet_adapter-14]   File "/home/will/humble_harmonic/rmf_ws/install/rmf_demos_fleet_adapter/lib/python3.10/site-packages/rmf_demos_fleet_adapter/fleet_adapter.py", line 181, in main
[fleet_adapter-14]     rclpy_executor.spin()
[fleet_adapter-14]   File "/opt/ros/humble/local/lib/python3.10/dist-packages/rclpy/executors.py", line 294, in spin
[fleet_adapter-14]     self.spin_once()
[fleet_adapter-14]   File "/opt/ros/humble/local/lib/python3.10/dist-packages/rclpy/executors.py", line 739, in spin_once
[fleet_adapter-14]     self._spin_once_impl(timeout_sec)
[fleet_adapter-14]   File "/opt/ros/humble/local/lib/python3.10/dist-packages/rclpy/executors.py", line 736, in _spin_once_impl
[fleet_adapter-14]     raise handler.exception()
[fleet_adapter-14]   File "/opt/ros/humble/local/lib/python3.10/dist-packages/rclpy/task.py", line 239, in __call__
[fleet_adapter-14]     self._handler.send(None)
[fleet_adapter-14]   File "/opt/ros/humble/local/lib/python3.10/dist-packages/rclpy/executors.py", line 437, in handler
[fleet_adapter-14]     await call_coroutine(entity, arg)
[fleet_adapter-14]   File "/opt/ros/humble/local/lib/python3.10/dist-packages/rclpy/executors.py", line 362, in _execute_subscription
[fleet_adapter-14]     await await_or_execute(sub.callback, msg)
[fleet_adapter-14]   File "/opt/ros/humble/local/lib/python3.10/dist-packages/rclpy/executors.py", line 107, in await_or_execute
[fleet_adapter-14]     return callback(*args)
[fleet_adapter-14]   File "/home/will/humble_harmonic/rmf_ws/install/rmf_demos_fleet_adapter/lib/python3.10/site-packages/rmf_demos_fleet_adapter/fleet_adapter.py", line 459, in lane_request_cb
[fleet_adapter-14]     closed_lanes.remove(lane_idx)
[fleet_adapter-14] KeyError: 2
```
This PR will check if `lane_idx` in `closed_lanes` before calling `closed_lanes.remove(lane_idx)`