### PR TITLE
Creation of emergency signal script

### DIFF
--- a/rmf_demos_tasks/rmf_demos_tasks/emergency_signal.py
+++ b/rmf_demos_tasks/rmf_demos_tasks/emergency_signal.py
@@ -57,8 +57,8 @@ class EmergencySignalPublisher(Node):
         )
 
         parser.add_argument(
-            '-f',
-            '--fleet',
+            '-F',
+            '--fleets',
             type=str,
             help='Fleets to trigger',
             nargs='+',

--- a/rmf_demos_tasks/rmf_demos_tasks/emergency_signal.py
+++ b/rmf_demos_tasks/rmf_demos_tasks/emergency_signal.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+
+# Copyright 2025 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Publish an emergency signal."""
+
+import argparse
+import sys
+
+import rclpy
+from rclpy.node import Node
+from rclpy.qos import QoSDurabilityPolicy as Durability
+from rclpy.qos import QoSProfile
+from rclpy.qos import QoSReliabilityPolicy as Reliability
+
+from rmf_fleet_msgs.msg import EmergencySignal
+
+###############################################################################
+
+def str2bool(v):
+    if v.lower() in ('yes', 'true', 't', 'y', '1'):
+        return True
+    elif v.lower() in ('no', 'false', 'f', 'n', '0'):
+        return False
+
+class EmergencySignalPublisher(Node):
+    """Emergency signal publisher."""
+
+    def __init__(self, argv=sys.argv):
+        """Initialize the emergency signal publisher."""
+        super().__init__('emergency_signal_publisher')
+        qos_profile = QoSProfile(
+            depth=10,
+            durability=Durability.VOLATILE,
+            reliability=Reliability.RELIABLE
+        )
+        self.publisher = self.create_publisher(EmergencySignal, 'emergency_signal', qos_profile)
+        
+        parser = argparse.ArgumentParser()
+        parser.add_argument(
+            'is_emergency',
+            type=str2bool,
+            help='Emergency message to publish (true or false)',
+        )
+
+        parser.add_argument(
+            '-f',
+            '--fleet',
+            type=str,
+            help='Fleets to trigger',
+            nargs='+',
+        )
+
+        self.args = parser.parse_args(argv[1:])
+        msg = EmergencySignal()
+        msg.is_emergency = self.args.is_emergency
+        self.get_logger().info('Publishing emergency signal: %s' % msg.is_emergency)
+        if self.args.fleet is not None:
+            msg.fleet_names = self.args.fleet
+            self.get_logger().info('Fleets: %s' % msg.fleet_names)
+        else:
+            self.get_logger().info('No fleets specified, sending to all fleets')
+        self.publisher.publish(msg)
+
+###############################################################################
+
+
+def main(argv=sys.argv):
+    """Publish an emergency signal."""
+    rclpy.init(args=sys.argv)
+    args_without_ros = rclpy.utilities.remove_ros_args(sys.argv)
+    signal_publisher = EmergencySignalPublisher(args_without_ros)
+    signal_publisher.destroy_node()
+    rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main(sys.argv)

--- a/rmf_demos_tasks/rmf_demos_tasks/emergency_signal.py
+++ b/rmf_demos_tasks/rmf_demos_tasks/emergency_signal.py
@@ -27,13 +27,13 @@ from rclpy.qos import QoSReliabilityPolicy as Reliability
 
 from rmf_fleet_msgs.msg import EmergencySignal
 
-###############################################################################
 
 def str2bool(v):
     if v.lower() in ('yes', 'true', 't', 'y', '1'):
         return True
     elif v.lower() in ('no', 'false', 'f', 'n', '0'):
         return False
+
 
 class EmergencySignalPublisher(Node):
     """Emergency signal publisher."""
@@ -48,7 +48,7 @@ class EmergencySignalPublisher(Node):
             reliability=Reliability.RELIABLE
         )
         self.publisher = self.create_publisher(EmergencySignal, 'emergency_signal', qos_profile)
-        
+
         parser = argparse.ArgumentParser()
         parser.add_argument(
             'is_emergency',
@@ -73,7 +73,7 @@ class EmergencySignalPublisher(Node):
             self.get_logger().info('Fleets: %s' % self.msg.fleet_names)
         else:
             self.get_logger().info('No fleets specified, sending to all fleets')
-        
+
         timer_period = 1.0  # seconds
         self.timer = self.create_timer(timer_period, self.timer_callback)
 

--- a/rmf_demos_tasks/rmf_demos_tasks/emergency_signal.py
+++ b/rmf_demos_tasks/rmf_demos_tasks/emergency_signal.py
@@ -29,6 +29,7 @@ from rmf_fleet_msgs.msg import EmergencySignal
 
 
 def str2bool(v):
+    """Convert a string to a boolean."""
     if v.lower() in ('yes', 'true', 't', 'y', '1'):
         return True
     elif v.lower() in ('no', 'false', 'f', 'n', '0'):
@@ -47,7 +48,8 @@ class EmergencySignalPublisher(Node):
             durability=Durability.TRANSIENT_LOCAL,
             reliability=Reliability.RELIABLE
         )
-        self.publisher = self.create_publisher(EmergencySignal, 'emergency_signal', qos_profile)
+        self.publisher = self.create_publisher(EmergencySignal,
+                                               'emergency_signal', qos_profile)
 
         parser = argparse.ArgumentParser()
         parser.add_argument(
@@ -67,12 +69,14 @@ class EmergencySignalPublisher(Node):
         self.args = parser.parse_args(argv[1:])
         self.msg = EmergencySignal()
         self.msg.is_emergency = self.args.is_emergency
-        self.get_logger().info('Publishing emergency signal: %s' % self.msg.is_emergency)
+        self.get_logger().info('Publishing emergency signal: %s' %
+                               self.msg.is_emergency)
         if self.args.fleets is not None:
             self.msg.fleet_names = self.args.fleets
             self.get_logger().info('Fleets: %s' % self.msg.fleet_names)
         else:
-            self.get_logger().info('No fleets specified, sending to all fleets')
+            self.get_logger().info('No fleets specified, '
+                                   'sending to all fleets')
 
         timer_period = 1.0  # seconds
         self.timer = self.create_timer(timer_period, self.timer_callback)

--- a/rmf_demos_tasks/rmf_demos_tasks/emergency_signal.py
+++ b/rmf_demos_tasks/rmf_demos_tasks/emergency_signal.py
@@ -68,8 +68,8 @@ class EmergencySignalPublisher(Node):
         self.msg = EmergencySignal()
         self.msg.is_emergency = self.args.is_emergency
         self.get_logger().info('Publishing emergency signal: %s' % self.msg.is_emergency)
-        if self.args.fleet is not None:
-            self.msg.fleet_names = self.args.fleet
+        if self.args.fleets is not None:
+            self.msg.fleet_names = self.args.fleets
             self.get_logger().info('Fleets: %s' % self.msg.fleet_names)
         else:
             self.get_logger().info('No fleets specified, sending to all fleets')

--- a/rmf_demos_tasks/setup.py
+++ b/rmf_demos_tasks/setup.py
@@ -43,7 +43,8 @@ setup(
             'dispatch_json = rmf_demos_tasks.dispatch_json:main',
             'api_request = rmf_demos_tasks.api_request:main',
             'wait_for_task_complete = \
-                rmf_demos_tasks.wait_for_task_complete:main'
+                rmf_demos_tasks.wait_for_task_complete:main',
+            'emergency_signal = rmf_demos_tasks.emergency_signal:main'
         ],
     },
 )


### PR DESCRIPTION
To aid users and developers on the new emergency signal pipeline, we created a test script that takes a required `boolean` message and optional fleet name array variable.

### To trigger an emergency to specific fleets:
```
ros2 run rmf_demos_tasks emergency_signal true -f tinyRobot deliveryRobot
```

### To deactivate an emergency to specific fleets:
```
ros2 run rmf_demos_tasks emergency_signal false -f tinyRobot deliveryRobot
```

### To trigger an emergency to all fleets:
```
ros2 run rmf_demos_tasks emergency_signal true
```

### To deactivate an emergency to all fleets:
```
ros2 run rmf_demos_tasks emergency_signal false
```

