### PR TITLE
set self.teleoperation to None when finish_action

### DIFF
--- a/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/fleet_adapter.py
+++ b/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/fleet_adapter.py
@@ -299,6 +299,7 @@ class RobotAdapter:
                 self.attempt_cmd_until_success(
                     cmd=self.api.toggle_teleop, args=(self.name, False)
                 )
+                self.teleoperation = None
 
     def perform_docking(self, destination):
         match self.api.start_activity(


### PR DESCRIPTION
## Bug fix

### Fixed bug

This PR prevents keep calling `self.teleoperation.update` after robot finishes **teleop** action.