### PR TITLE
Use 9 as default gazebo_version

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ These demos were built and tested on
 
 * [Ubuntu 24.04 LTS](https://releases.ubuntu.com/24.04/)
 
-* [ROS 2 - Jazzy](https://docs.ros.org/en/jazzy/Releases/Release-Jazzy-Jalisco.html)
+* [ROS 2 - Rolling](https://docs.ros.org/en/jazzy/Releases/Release-Rolling-Ridley.html)
 
-* [Gazebo Harmonic](https://gazebosim.org/docs/harmonic)
-> Note: RMF is fully supported on ROS 2 Humble and Iron as well, but those will require [ros_gz](https://github.com/gazebosim/ros_gz) to be built from source.
+* [Gazebo Ionic](https://gazebosim.org/docs/ionic)
+> Note: The `main` branches of the core RMF libraries are fully supported on ROS 2 Humble, Iron, and Jazzy as well, but you will need to use the distro-specific branches for `rmf_traffic_editor`, `rmf_simulation`, and `rmf_demos`.
 
 ## Installation
 Instructions can be found [here](https://github.com/open-rmf/rmf).

--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ These demos were built and tested on
 * [ROS 2 - Rolling](https://docs.ros.org/en/jazzy/Releases/Release-Rolling-Ridley.html)
 
 * [Gazebo Ionic](https://gazebosim.org/docs/ionic)
-> Note: The `main` branches of the core RMF libraries are fully supported on ROS 2 Humble, Iron, and Jazzy as well, but you will need to use the distro-specific branches for `rmf_traffic_editor`, `rmf_simulation`, and `rmf_demos`.
+> Note: The `main` branches of the core RMF libraries are fully supported on ROS 2 Humble, Iron, and Jazzy as well, but you will need to use the distro-specific branches for `rmf_traffic_editor` and `rmf_simulation`.
+>
+> You can use `rmf_demos` with any ROS distro by explicitly setting the `gazebo_version:=#` launch parameter, replacing `#` with the appropriate version of Gazebo for that ROS distro, e.g. `8` for `Jazzy`.
 
 ## Installation
 Instructions can be found [here](https://github.com/open-rmf/rmf).

--- a/rmf_demos_gz/launch/airport_terminal.launch.xml
+++ b/rmf_demos_gz/launch/airport_terminal.launch.xml
@@ -3,7 +3,7 @@
 <launch>
   <arg name="use_sim_time" default="true"/>
   <arg name="failover_mode" default="false"/>
-  <arg name="gazebo_version" default='8'/>
+  <arg name="gazebo_version" default='9'/>
   <arg name="sim_update_rate" default='100'/>
 
   <!-- Common launch -->

--- a/rmf_demos_gz/launch/battle_royale.launch.xml
+++ b/rmf_demos_gz/launch/battle_royale.launch.xml
@@ -2,7 +2,7 @@
 
 <launch>
   <arg name="use_sim_time" default="true"/>
-  <arg name="gazebo_version" default='8'/>
+  <arg name="gazebo_version" default='9'/>
   <arg name="use_traffic_light" default="false"/>
   <arg name="sim_update_rate" default='100'/>
 

--- a/rmf_demos_gz/launch/campus.launch.xml
+++ b/rmf_demos_gz/launch/campus.launch.xml
@@ -3,7 +3,7 @@
 <launch>
   <arg name="use_sim_time" default="true"/>
   <arg name="failover_mode" default="false"/>
-  <arg name="gazebo_version" default='8'/>
+  <arg name="gazebo_version" default='9'/>
   <arg name="sim_update_rate" default='100'/>
 
   <!-- Common launch -->

--- a/rmf_demos_gz/launch/clinic.launch.xml
+++ b/rmf_demos_gz/launch/clinic.launch.xml
@@ -3,7 +3,7 @@
 <launch>
   <arg name="use_sim_time" default="true"/>
   <arg name="failover_mode" default="false"/>
-  <arg name="gazebo_version" default='8'/>
+  <arg name="gazebo_version" default='9'/>
   <arg name="sim_update_rate" default='100'/>
 
   <!-- Common launch -->

--- a/rmf_demos_gz/launch/hotel.launch.xml
+++ b/rmf_demos_gz/launch/hotel.launch.xml
@@ -3,7 +3,7 @@
 <launch>
   <arg name="use_sim_time" default="true"/>
   <arg name="failover_mode" default="false"/>
-  <arg name="gazebo_version" default='8'/>
+  <arg name="gazebo_version" default='9'/>
   <arg name="sim_update_rate" default='100'/>
 
   <!-- Common launch -->

--- a/rmf_demos_gz/launch/office.launch.xml
+++ b/rmf_demos_gz/launch/office.launch.xml
@@ -3,7 +3,7 @@
 <launch>
   <arg name="use_sim_time" default="true"/>
   <arg name="failover_mode" default="false"/>
-  <arg name="gazebo_version" default='8'/>
+  <arg name="gazebo_version" default='9'/>
   <arg name="sim_update_rate" default='100'/>
 
   <!-- Common launch -->

--- a/rmf_demos_gz/launch/office_mock_traffic_light.launch.xml
+++ b/rmf_demos_gz/launch/office_mock_traffic_light.launch.xml
@@ -2,7 +2,7 @@
 
 <launch>
   <arg name="use_sim_time" default="true"/>
-  <arg name="gazebo_version" default='8'/>
+  <arg name="gazebo_version" default='9'/>
   <arg name="sim_update_rate" default='100'/>
 
   <!-- Common launch -->

--- a/rmf_demos_gz/launch/simulation.launch.xml
+++ b/rmf_demos_gz/launch/simulation.launch.xml
@@ -4,7 +4,7 @@
   <arg name="map_package" default="rmf_demos_maps" description="Name of the map package" />
   <arg name="map_name" description="Name of the rmf_demos map to simulate" />
   <arg name="use_crowdsim" default='0'/>
-  <arg name="gazebo_version" default='8'/>
+  <arg name="gazebo_version" default='9'/>
   <arg name="sim_update_rate" default='100'/>
 
   <let name="world_path" value="$(find-pkg-share $(var map_package))/maps/$(var map_name)/$(var map_name).world" />

--- a/rmf_demos_gz/launch/triple_H.launch.xml
+++ b/rmf_demos_gz/launch/triple_H.launch.xml
@@ -2,7 +2,7 @@
 
 <launch>
   <arg name="use_sim_time" default="true"/>
-  <arg name="gazebo_version" default='8'/>
+  <arg name="gazebo_version" default='9'/>
   <arg name="sim_update_rate" default='100'/>
 
   <!-- Common launch -->


### PR DESCRIPTION
gz-sim 9 is the version of Gazebo that is vendored on the current rolling branch, so we should target that version by default in order to get rmf_demos released on rolling.