### PR TITLE
Demos main no longer compatible with rmf_simulation jazzy

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,7 @@ These demos were built and tested on
 * [ROS 2 - Rolling](https://docs.ros.org/en/jazzy/Releases/Release-Rolling-Ridley.html)
 
 * [Gazebo Ionic](https://gazebosim.org/docs/ionic)
-> Note: The `main` branches of the core RMF libraries are fully supported on ROS 2 Humble, Iron, and Jazzy as well, but you will need to use the distro-specific branches for `rmf_traffic_editor` and `rmf_simulation`.
->
-> You can use `rmf_demos` with any ROS distro by explicitly setting the `gazebo_version:=#` launch parameter, replacing `#` with the appropriate version of Gazebo for that ROS distro, e.g. `8` for `Jazzy`.
+> Note: The `main` branches of the core RMF libraries are fully supported on ROS 2 Humble, Iron, and Jazzy as well, but you will need to use the distro-specific branches for `rmf_traffic_editor`, `rmf_simulation` and `rmf_demos`.
 
 ## Installation
 Instructions can be found [here](https://github.com/open-rmf/rmf).


### PR DESCRIPTION
Updating readme to reflect distro/library compatibility.

Due to https://github.com/open-rmf/rmf_demos/pull/262 (on rmf_demos `main`) depending on https://github.com/open-rmf/rmf_simulation/pull/136 (available in rmf_simulation `main` but not `jazzy`), environment hooks for plugin paths are absent in rmf_simulation `jazzy`, so rmf_demos `main` is no longer compatible with all RMF distros, and has to match rmf_simulation between `main` and `jazzy`.