### PR TITLE
Remove gazebo_version argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ These demos were built and tested on
 * [Gazebo Ionic](https://gazebosim.org/docs/ionic)
 > Note: The `main` branches of the core RMF libraries are fully supported on ROS 2 Humble, Iron, and Jazzy as well, but you will need to use the distro-specific branches for `rmf_traffic_editor` and `rmf_simulation`.
 >
-> You can use `rmf_demos` with any ROS distro by explicitly setting the `gazebo_version:=#` launch parameter, replacing `#` with the appropriate version of Gazebo for that ROS distro, e.g. `8` for `Jazzy`.
 
 ## Installation
 Instructions can be found [here](https://github.com/open-rmf/rmf).

--- a/rmf_demos_gz/launch/airport_terminal.launch.xml
+++ b/rmf_demos_gz/launch/airport_terminal.launch.xml
@@ -3,7 +3,6 @@
 <launch>
   <arg name="use_sim_time" default="true"/>
   <arg name="failover_mode" default="false"/>
-  <arg name="gazebo_version" default=''/>
   <arg name="sim_update_rate" default='100'/>
 
   <!-- Common launch -->
@@ -15,7 +14,6 @@
   <!-- Simulation launch -->
   <include file="$(find-pkg-share rmf_demos_gz)/simulation.launch.xml">
     <arg name="map_name" value="airport_terminal" />
-    <arg name="gazebo_version" value="$(var gazebo_version)" />
     <arg name="sim_update_rate" value="$(var sim_update_rate)"/>
   </include>
 

--- a/rmf_demos_gz/launch/airport_terminal.launch.xml
+++ b/rmf_demos_gz/launch/airport_terminal.launch.xml
@@ -3,7 +3,7 @@
 <launch>
   <arg name="use_sim_time" default="true"/>
   <arg name="failover_mode" default="false"/>
-  <arg name="gazebo_version" default='9'/>
+  <arg name="gazebo_version" default=''/>
   <arg name="sim_update_rate" default='100'/>
 
   <!-- Common launch -->

--- a/rmf_demos_gz/launch/battle_royale.launch.xml
+++ b/rmf_demos_gz/launch/battle_royale.launch.xml
@@ -2,7 +2,7 @@
 
 <launch>
   <arg name="use_sim_time" default="true"/>
-  <arg name="gazebo_version" default='9'/>
+  <arg name="gazebo_version" default=''/>
   <arg name="use_traffic_light" default="false"/>
   <arg name="sim_update_rate" default='100'/>
 

--- a/rmf_demos_gz/launch/battle_royale.launch.xml
+++ b/rmf_demos_gz/launch/battle_royale.launch.xml
@@ -2,7 +2,6 @@
 
 <launch>
   <arg name="use_sim_time" default="true"/>
-  <arg name="gazebo_version" default=''/>
   <arg name="use_traffic_light" default="false"/>
   <arg name="sim_update_rate" default='100'/>
 
@@ -15,7 +14,6 @@
   <!-- Simulation launch -->
   <include file="$(find-pkg-share rmf_demos_gz)/simulation.launch.xml">
     <arg name="map_name" value="battle_royale" />
-    <arg name="gazebo_version" value="$(var gazebo_version)" />
     <arg name="sim_update_rate" value="$(var sim_update_rate)"/>
   </include>
 

--- a/rmf_demos_gz/launch/campus.launch.xml
+++ b/rmf_demos_gz/launch/campus.launch.xml
@@ -3,7 +3,6 @@
 <launch>
   <arg name="use_sim_time" default="true"/>
   <arg name="failover_mode" default="false"/>
-  <arg name="gazebo_version" default=''/>
   <arg name="sim_update_rate" default='100'/>
 
   <!-- Common launch -->
@@ -15,7 +14,6 @@
   <!-- Simulation launch -->
   <include file="$(find-pkg-share rmf_demos_gz)/simulation.launch.xml">
     <arg name="map_name" value="campus" />
-    <arg name="gazebo_version" value="$(var gazebo_version)" />
     <arg name="sim_update_rate" value="$(var sim_update_rate)"/>
   </include>
 

--- a/rmf_demos_gz/launch/campus.launch.xml
+++ b/rmf_demos_gz/launch/campus.launch.xml
@@ -3,7 +3,7 @@
 <launch>
   <arg name="use_sim_time" default="true"/>
   <arg name="failover_mode" default="false"/>
-  <arg name="gazebo_version" default='9'/>
+  <arg name="gazebo_version" default=''/>
   <arg name="sim_update_rate" default='100'/>
 
   <!-- Common launch -->

--- a/rmf_demos_gz/launch/clinic.launch.xml
+++ b/rmf_demos_gz/launch/clinic.launch.xml
@@ -3,7 +3,6 @@
 <launch>
   <arg name="use_sim_time" default="true"/>
   <arg name="failover_mode" default="false"/>
-  <arg name="gazebo_version" default=''/>
   <arg name="sim_update_rate" default='100'/>
 
   <!-- Common launch -->
@@ -15,7 +14,6 @@
   <!-- Simulation launch -->
   <include file="$(find-pkg-share rmf_demos_gz)/simulation.launch.xml">
     <arg name="map_name" value="clinic" />
-    <arg name="gazebo_version" value="$(var gazebo_version)" />
     <arg name="sim_update_rate" value="$(var sim_update_rate)"/>
   </include>
 

--- a/rmf_demos_gz/launch/clinic.launch.xml
+++ b/rmf_demos_gz/launch/clinic.launch.xml
@@ -3,7 +3,7 @@
 <launch>
   <arg name="use_sim_time" default="true"/>
   <arg name="failover_mode" default="false"/>
-  <arg name="gazebo_version" default='9'/>
+  <arg name="gazebo_version" default=''/>
   <arg name="sim_update_rate" default='100'/>
 
   <!-- Common launch -->

--- a/rmf_demos_gz/launch/hotel.launch.xml
+++ b/rmf_demos_gz/launch/hotel.launch.xml
@@ -3,7 +3,6 @@
 <launch>
   <arg name="use_sim_time" default="true"/>
   <arg name="failover_mode" default="false"/>
-  <arg name="gazebo_version" default=''/>
   <arg name="sim_update_rate" default='100'/>
 
   <!-- Common launch -->
@@ -15,7 +14,6 @@
   <!-- Simulation launch -->
   <include file="$(find-pkg-share rmf_demos_gz)/simulation.launch.xml">
     <arg name="map_name" value="hotel" />
-    <arg name="gazebo_version" value="$(var gazebo_version)" />
     <arg name="sim_update_rate" value="$(var sim_update_rate)"/>
   </include>
 </launch>

--- a/rmf_demos_gz/launch/hotel.launch.xml
+++ b/rmf_demos_gz/launch/hotel.launch.xml
@@ -3,7 +3,7 @@
 <launch>
   <arg name="use_sim_time" default="true"/>
   <arg name="failover_mode" default="false"/>
-  <arg name="gazebo_version" default='9'/>
+  <arg name="gazebo_version" default=''/>
   <arg name="sim_update_rate" default='100'/>
 
   <!-- Common launch -->

--- a/rmf_demos_gz/launch/office.launch.xml
+++ b/rmf_demos_gz/launch/office.launch.xml
@@ -3,7 +3,6 @@
 <launch>
   <arg name="use_sim_time" default="true"/>
   <arg name="failover_mode" default="false"/>
-  <arg name="gazebo_version" default=''/>
   <arg name="sim_update_rate" default='100'/>
 
   <!-- Common launch -->
@@ -15,7 +14,6 @@
   <!-- Simulation launch -->
   <include file="$(find-pkg-share rmf_demos_gz)/simulation.launch.xml">
     <arg name="map_name" value="office" />
-    <arg name="gazebo_version" value="$(var gazebo_version)" />
     <arg name="sim_update_rate" value="$(var sim_update_rate)"/>
   </include>
 

--- a/rmf_demos_gz/launch/office.launch.xml
+++ b/rmf_demos_gz/launch/office.launch.xml
@@ -3,7 +3,7 @@
 <launch>
   <arg name="use_sim_time" default="true"/>
   <arg name="failover_mode" default="false"/>
-  <arg name="gazebo_version" default='9'/>
+  <arg name="gazebo_version" default=''/>
   <arg name="sim_update_rate" default='100'/>
 
   <!-- Common launch -->

--- a/rmf_demos_gz/launch/office_mock_traffic_light.launch.xml
+++ b/rmf_demos_gz/launch/office_mock_traffic_light.launch.xml
@@ -2,7 +2,7 @@
 
 <launch>
   <arg name="use_sim_time" default="true"/>
-  <arg name="gazebo_version" default='9'/>
+  <arg name="gazebo_version" default=''/>
   <arg name="sim_update_rate" default='100'/>
 
   <!-- Common launch -->

--- a/rmf_demos_gz/launch/office_mock_traffic_light.launch.xml
+++ b/rmf_demos_gz/launch/office_mock_traffic_light.launch.xml
@@ -2,7 +2,6 @@
 
 <launch>
   <arg name="use_sim_time" default="true"/>
-  <arg name="gazebo_version" default=''/>
   <arg name="sim_update_rate" default='100'/>
 
   <!-- Common launch -->
@@ -13,7 +12,6 @@
   <!-- Simulation launch -->
   <include file="$(find-pkg-share rmf_demos_gz)/simulation.launch.xml">
     <arg name="map_name" value="office" />
-    <arg name="gazebo_version" value="$(var gazebo_version)" />
   </include>
 
 </launch>

--- a/rmf_demos_gz/launch/simulation.launch.xml
+++ b/rmf_demos_gz/launch/simulation.launch.xml
@@ -4,7 +4,6 @@
   <arg name="map_package" default="rmf_demos_maps" description="Name of the map package" />
   <arg name="map_name" description="Name of the rmf_demos map to simulate" />
   <arg name="use_crowdsim" default='0'/>
-  <arg name="gazebo_version" default=''/>
   <arg name="sim_update_rate" default='100'/>
 
   <let name="world_path" value="$(find-pkg-share $(var map_package))/maps/$(var map_name)/$(var map_name).world" />
@@ -17,11 +16,8 @@
   <let name="gz_headless" if="$(var headless)" value="-s"/>
   <let name="gz_headless" unless="$(var headless)" value="" />
 
-  <let name="force_version" if="$(var gazebo_version)" value="--force-version $(var gazebo_version)"/>
-  <let name="force_version" unless="$(var gazebo_version)" value=""/>
-
   <!-- TODO(luca) Remove the manual concatenation of GZ_SIM_RESOURCE_PATH and just use environment hooks -->
-  <executable cmd="gz sim $(var force_version) $(var gz_headless) -r -v 3 $(var world_path) -z $(var sim_update_rate)" output="both">
+  <executable cmd="gz sim $(var gz_headless) -r -v 3 $(var world_path) -z $(var sim_update_rate)" output="both">
     <env name="GZ_SIM_RESOURCE_PATH" value="$(env GZ_SIM_RESOURCE_PATH):$(var model_path)" />
     <env name="MENGE_RESOURCE_PATH" value="$(var menge_resource_path)"/>
   </executable>

--- a/rmf_demos_gz/launch/simulation.launch.xml
+++ b/rmf_demos_gz/launch/simulation.launch.xml
@@ -4,7 +4,7 @@
   <arg name="map_package" default="rmf_demos_maps" description="Name of the map package" />
   <arg name="map_name" description="Name of the rmf_demos map to simulate" />
   <arg name="use_crowdsim" default='0'/>
-  <arg name="gazebo_version" default='9'/>
+  <arg name="gazebo_version" default=''/>
   <arg name="sim_update_rate" default='100'/>
 
   <let name="world_path" value="$(find-pkg-share $(var map_package))/maps/$(var map_name)/$(var map_name).world" />
@@ -17,8 +17,11 @@
   <let name="gz_headless" if="$(var headless)" value="-s"/>
   <let name="gz_headless" unless="$(var headless)" value="" />
 
+  <let name="force_version" if="$(var gazebo_version)" value="--force-version $(var gazebo_version)"/>
+  <let name="force_version" unless="$(var gazebo_version)" value=""/>
+
   <!-- TODO(luca) Remove the manual concatenation of GZ_SIM_RESOURCE_PATH and just use environment hooks -->
-  <executable cmd="gz sim --force-version $(var gazebo_version) $(var gz_headless) -r -v 3 $(var world_path) -z $(var sim_update_rate)" output="both">
+  <executable cmd="gz sim $(var force_version) $(var gz_headless) -r -v 3 $(var world_path) -z $(var sim_update_rate)" output="both">
     <env name="GZ_SIM_RESOURCE_PATH" value="$(env GZ_SIM_RESOURCE_PATH):$(var model_path)" />
     <env name="MENGE_RESOURCE_PATH" value="$(var menge_resource_path)"/>
   </executable>

--- a/rmf_demos_gz/launch/triple_H.launch.xml
+++ b/rmf_demos_gz/launch/triple_H.launch.xml
@@ -2,7 +2,6 @@
 
 <launch>
   <arg name="use_sim_time" default="true"/>
-  <arg name="gazebo_version" default=''/>
   <arg name="sim_update_rate" default='100'/>
 
   <!-- Common launch -->
@@ -13,7 +12,6 @@
   <!-- Simulation launch -->
   <include file="$(find-pkg-share rmf_demos_gz)/simulation.launch.xml">
     <arg name="map_name" value="triple_H" />
-    <arg name="gazebo_version" value="$(var gazebo_version)" />
     <arg name="sim_update_rate" value="$(var sim_update_rate)"/>
   </include>
 

--- a/rmf_demos_gz/launch/triple_H.launch.xml
+++ b/rmf_demos_gz/launch/triple_H.launch.xml
@@ -2,7 +2,7 @@
 
 <launch>
   <arg name="use_sim_time" default="true"/>
-  <arg name="gazebo_version" default='9'/>
+  <arg name="gazebo_version" default=''/>
   <arg name="sim_update_rate" default='100'/>
 
   <!-- Common launch -->


### PR DESCRIPTION
Alternative to https://github.com/open-rmf/rmf_demos/pull/292

I opened this PR because I found myself using Jazzy and having to add a `gazebo_version:=8` to my launch file or demos wouldn't run.

The idea behind the `gazebo_version` argument is that it allows people who want to co-install different version of gazebo side by side to choose which one they want to use at runtime.
I would argue that this use case is increasingly uncommon for two reasons:

* Since we moved the dependency to use the [ROS vendored gz_sim package](https://github.com/open-rmf/rmf_demos/blob/7e995cbd39dc2fc1fbf594e84874fc0df64092ff/rmf_demos_gz/package.xml#L21), the gazebo that we officially support will be automatically installed by rosdep. Users won't need to manually install Gazebo versions themselves.
* Gazebo itself is moving away from supporting side by side installations and it actually won't be supported from Jetty onwards https://github.com/gazebo-tooling/release-tools/issues/1244.

By removing arguments we have one less line to maintain and, most importantly, both Kilted and Jazzy users running `rmf_demos` on `main` will be able to just run:

```
ros2 launch rmf_demos_gz office.launch.xml
```

And have it work, by contrast if we specify a default version either Kilted or Jazzy users will have to add a custom command line argument.

What this PR will break is people who co-install both the `gz-sim-vendor` package and a different gazebo version, either from binaries or source, but again this will be effectively unsupported from the next Gazebo LTS.