### PR TITLE
Use builtin gazebo model downloading

### DIFF
--- a/rmf_demos_gz/launch/simulation.launch.xml
+++ b/rmf_demos_gz/launch/simulation.launch.xml
@@ -7,7 +7,7 @@
   <arg name="sim_update_rate" default='100'/>
 
   <let name="world_path" value="$(find-pkg-share $(var map_package))/maps/$(var map_name)/$(var map_name).world" />
-  <let name="model_path" value="$(find-pkg-share $(var map_package))/maps/$(var map_name)/models:$(env HOME)/.gazebo/models" />
+  <let name="model_path" value="$(find-pkg-share $(var map_package))/maps/$(var map_name)/models" />
 
   <!-- Use crowd sim if `use_crowdsim` is true-->
   <let name="menge_resource_path" if="$(var use_crowdsim)" value="$(find-pkg-share $(var map_package))/maps/$(var map_name)/config_resource"/>

--- a/rmf_demos_maps/CMakeLists.txt
+++ b/rmf_demos_maps/CMakeLists.txt
@@ -13,6 +13,13 @@ ament_package()
 
 file(GLOB_RECURSE traffic_editor_paths "maps/*.building.yaml")
 
+if (NOT NO_DOWNLOAD_MODELS)
+  add_custom_target(
+    update_model_cache
+    COMMAND ros2 run rmf_building_map_tools building_map_model_downloader
+  )
+endif()
+
 foreach(path ${traffic_editor_paths})
 
   # Get the output world name
@@ -30,20 +37,12 @@ foreach(path ${traffic_editor_paths})
   ##############################################################################
 
   message("BUILDING WORLDFILE WITH COMMAND: ros2 run rmf_building_map_tools building_map_generator gazebo ${map_path} ${output_world_path} ${output_model_dir}")
-  if (NO_DOWNLOAD_MODELS)
-    add_custom_command(
-      DEPENDS ${map_path}
-      COMMAND ros2 run rmf_building_map_tools building_map_generator gazebo ${map_path} ${output_world_path} ${output_model_dir}
-      OUTPUT ${output_world_path}
-    )
-  else()
-    message("DOWNLOADING MODELS WITH COMMAND: ros2 run rmf_building_map_tools building_map_model_downloader ${map_path}")
-    add_custom_command(
-      DEPENDS ${map_path}
-      COMMAND ros2 run rmf_building_map_tools building_map_generator gazebo ${map_path} ${output_world_path} ${output_model_dir}
-      COMMAND ros2 run rmf_building_map_tools building_map_model_downloader ${map_path} -e ~/.gazebo/models
-      OUTPUT ${output_world_path}
-    )
+  add_custom_target(
+    ${world_name}
+    COMMAND ros2 run rmf_building_map_tools building_map_generator gazebo ${map_path} ${output_world_path} ${output_model_dir}
+  )
+  if (NOT NO_DOWNLOAD_MODELS)
+    add_dependencies(${world_name} update_model_cache)
   endif()
 
   ##############################################################################
@@ -54,7 +53,7 @@ foreach(path ${traffic_editor_paths})
   add_custom_command(
     OUTPUT ${world_name}_crowdsim
     COMMAND ros2 run rmf_building_map_tools building_crowdsim ${map_path} ${crowd_sim_config_resource} ${output_world_path}
-    DEPENDS ${output_world_path}
+    DEPENDS ${world_name}
   )
 
   # This will initiate both custom commands: ${output_world_path} and ${world_name}_crowdsim


### PR DESCRIPTION
## New feature implementation

### Implemented feature

Needs https://github.com/open-rmf/rmf_traffic_editor/pull/535, also closes https://github.com/open-rmf/rmf_traffic_editor/issues/534

### Implementation description

The upstream PR has most of the description, by using Gazebo itself to download models we won't need custom paths anymore (such as the user's home folder) cutting down on build times and most importantly unblocking distribution of `rmf_demos_maps` binaries.