### PR TITLE
Add mutex group supervisor to common launch file

### DIFF
--- a/rmf_demos/launch/common.launch.xml
+++ b/rmf_demos/launch/common.launch.xml
@@ -65,7 +65,13 @@
 
   <!-- Proto-Reservation system-->
   <group  if="$(var use_reservation_node)">
-    <node pkg="rmf_reservation_node" exec="queue_manager"></node>
+    <node pkg="rmf_reservation_node" exec="queue_manager"/>
   </group>
+
+  <!-- Mutex Group Supervisor, manages the locking and unlocking of mutex groups -->
+  <group>
+    <node pkg="rmf_fleet_adapter" exec="mutex_group_supervisor"/>
+  </group>
+
 
 </launch>


### PR DESCRIPTION
Following https://github.com/open-rmf/rmf_ros2/pull/310 the mutex group supervisor was never added to the launch files for `rmf_demos`.

To some extent this is because the mutex group supervisor is not something being used in any of the demo maps currently, but nevertheless it may be confusing for users who try to edit the demo maps to experiment with mutex groups and find that they aren't working. It will also be confusing for users who model their own projects off of the demos and find that mutex groups aren't working in their projects.

I didn't put any launch parameter to toggle mutex groups on/off because it doesn't have any particularly negative effects if it's run for cases that don't need it, but we could add a launch parameter for it if anyone thinks it matters.