### PR TITLE
Fixes cancel task stuck indefinitely

### DIFF
--- a/rmf_demos_tasks/rmf_demos_tasks/cancel_task.py
+++ b/rmf_demos_tasks/rmf_demos_tasks/cancel_task.py
@@ -27,7 +27,7 @@ from rclpy.qos import QoSHistoryPolicy as History
 from rclpy.qos import QoSProfile
 from rclpy.qos import QoSReliabilityPolicy as Reliability
 
-from rmf_task_msgs.msg import ApiRequest
+from rmf_task_msgs.msg import ApiRequest, ApiResponse
 
 ###############################################################################
 
@@ -61,6 +61,16 @@ class TaskRequester(Node):
             ApiRequest, 'task_api_requests', transient_qos
         )
 
+        self.response = rclpy.Future()
+
+        def receive_response(response_msg: ApiResponse):
+            if response_msg.request_id == msg.request_id:
+                self.response.set_result(json.loads(response_msg.json_msg))
+
+        self.sub = self.create_subscription(
+            ApiResponse, 'task_api_responses', receive_response, transient_qos
+        )
+
         # Construct task
         msg = ApiRequest()
         msg.request_id = 'cancel_task_' + str(uuid.uuid4())
@@ -82,7 +92,13 @@ def main(argv=sys.argv):
     args_without_ros = rclpy.utilities.remove_ros_args(sys.argv)
 
     task_requester = TaskRequester(args_without_ros)
-    rclpy.spin_once(task_requester)
+    rclpy.spin_until_future_complete(
+        task_requester, task_requester.response, timeout_sec=5.0
+    )
+    if task_requester.response.done():
+        print(f'Got response: \n{task_requester.response.result()}')
+    else:
+        print('Did not get a response')
     rclpy.shutdown()
 
 


### PR DESCRIPTION
## Bug fix

### Fixed bug

Fixes https://github.com/open-rmf/rmf_demos/issues/319. Also adds the check that the cancellation was successful.

### Fix applied


### Test

Start office sim,

```bash
ros2 launch rmf_demos_gz office.launch.xml headless:=0
```

Start a task,

```bash
ros2 run rmf_demos_tasks dispatch_patrol -n 1 -p patrol -st 0 --use_sim_time
```

Take note of the task ID, cancel it,

```bash
ros2 run rmf_demos_tasks cancel_task -id <TASK_ID>
```

### GenAI Use
We follow [OSRA's policy on GenAI tools](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md)

- [ ] I used a GenAI tool in this PR.
- [x] I did not use GenAI

Generated-by:
