### PR TITLE
Add a --start-at-departure option for dispatch_go_to_place

### DIFF
--- a/rmf_demos_tasks/rmf_demos_tasks/dispatch_go_to_place.py
+++ b/rmf_demos_tasks/rmf_demos_tasks/dispatch_go_to_place.py
@@ -109,9 +109,9 @@ class TaskRequester(Node):
             '--start-at-departure',
             action='store_true',
             help=(
-                'Request the robot to not start going to its destination until '
-                'the task start time has been reached, rather than trying to '
-                'arrive at the destination at the task start time.'
+                'Request the robot to not start going to its destination '
+                'until the task start time has been reached, rather than '
+                'trying to arrive at the destination at the task start time.'
             )
         )
 

--- a/rmf_demos_tasks/rmf_demos_tasks/dispatch_go_to_place.py
+++ b/rmf_demos_tasks/rmf_demos_tasks/dispatch_go_to_place.py
@@ -105,6 +105,15 @@ class TaskRequester(Node):
                 'setting.'
             ),
         )
+        parser.add_argument(
+            '--start-at-departure',
+            action='store_true',
+            help=(
+                'Request the robot to not start going to its destination until '
+                'the task start time has been reached, rather than trying to '
+                'arrive at the destination at the task start time.'
+            )
+        )
 
         self.args = parser.parse_args(argv[1:])
         self.response = asyncio.Future()
@@ -170,6 +179,9 @@ class TaskRequester(Node):
             go_to_description['constraints'] = [
                 {'category': 'prefer_same_map'}
             ]
+
+        if self.args.start_at_departure:
+            go_to_description['start_at_departure'] = True
 
         go_to_activity = {
             'category': 'go_to_place',


### PR DESCRIPTION
This PR is motivated by #467 which introduces the `start_at_departure` option for `go_to_place` events.

In this PR we add a `--start-at-departure` flag for `dispatch_go_to_place` so we can test the behavior of the new flag.

To try it out, launch the hotel world:

```bash
ros2 launch rmf_demos_gz hotel.launch.xml
```

Then in another terminal dispatch a `go_to_place` task for `tinyBot_1`, telling it to start at the 90s mark:

```bash
ros2 run rmf_demos_tasks dispatch_go_to_place --use_sim_time -F tinyRobot -R tinyBot_1 -p L2_master_suite -st 90
```

The robot should start moving to the goal right away because the default behavior is to arrive at the goal by the start time. 

Now if you restart the simulation and try again with the new flag, the robot should wait at its charger until the simulation reaches its 90s mark:

```bash
ros2 run rmf_demos_tasks dispatch_go_to_place --use_sim_time -F tinyRobot -R tinyBot_1 -p L2_master_suite -st 90 --start-at-departure
```