### PR TITLE
Add task_assignment_strategy to fleet config

### DIFF
--- a/rmf_demos/config/office/tinyRobot_config.yaml
+++ b/rmf_demos/config/office/tinyRobot_config.yaml
@@ -34,6 +34,7 @@ rmf_fleet:
   responsive_wait: False # Should responsive wait be on/off for the whole fleet by default? False if not specified.
   use_parking_reservations: True
   reassign_task_interval: 120 # seconds, specify how often a task reassignment should be triggered in the fleet
+  task_assignment_strategy: "ShortestFinishTime" # Task planning strategy eg.["ShortestFinishTime", "IdlePreferred"]
   robots:
     tinyRobot1:
         charger: "tinyRobot1_charger"

--- a/rmf_demos/config/office/tinyRobot_config.yaml
+++ b/rmf_demos/config/office/tinyRobot_config.yaml
@@ -34,7 +34,19 @@ rmf_fleet:
   responsive_wait: False # Should responsive wait be on/off for the whole fleet by default? False if not specified.
   use_parking_reservations: True
   reassign_task_interval: 120 # seconds, specify how often a task reassignment should be triggered in the fleet
-  task_assignment_strategy: "ShortestFinishTime" # Task planning strategy eg.["ShortestFinishTime", "IdlePreferred"]
+  task_assignment_strategy:
+    profile: "DefaultFastest"   # [DefaultFastest, BatteryAware, Custom]
+    # DefaultFastest: Prioritize task efficiency (fastest finish time)
+    # BatteryAware: Optimize throughput with battery SoC in mind
+    # Custom: Use custom weights below
+    weights:  # polynomial coeffs
+      finish_time: [0.0, 1.0] # task finish time cost
+      battery_penalty: [0.0, 5.0, 20.0] # battery penalty for low SoC
+      busy_penalty: [0.0, 60.0] # penalty for assigning tasks to busy robots, 2 modes:
+                                #   Binary: penalty applied if robot is busy with any task
+                                #   Count: penalty increases with number of tasks assigned to robot
+    options:
+      busy_mode: "Binary"   # [Binary, Count]
   robots:
     tinyRobot1:
         charger: "tinyRobot1_charger"


### PR DESCRIPTION
This PR is related to rmf_task open-rmf/rmf_task#129.

It adds a new parameter called: task_assignment_strategy in the fleet_config.