### PR TITLE
Add use_site_map param

### DIFF
--- a/rmf_demos/package.xml
+++ b/rmf_demos/package.xml
@@ -17,7 +17,6 @@
   <exec_depend>rmf_task_ros2</exec_depend>
   <exec_depend>rmf_fleet_adapter</exec_depend>
   <exec_depend>rmf_building_map_tools</exec_depend>
-  <exec_depend>rmf_site_map_server</exec_depend>
 
   <exec_depend>rmf_visualization</exec_depend>
 


### PR DESCRIPTION
Add `use_site_map` param to toggle between serving maps with legacy `rmf_building_map_tools` or the latest `rmf_site_map_server`