### PR TITLE
Lyrical compatibility

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,4 +18,4 @@ jobs:
         rmf_demos_gz
         rmf_demos_maps
         rmf_demos_tasks
-      dist-matrix: '[{"ros_distribution": "rolling", "ubuntu_distribution": "noble"}]'
+      dist-matrix: '[{"ros_distribution": "rolling", "ubuntu_distribution": "resolute"}]'

--- a/rmf_demos_bridges/setup.py
+++ b/rmf_demos_bridges/setup.py
@@ -19,7 +19,9 @@ setup(
     maintainer_email='cnboonhan@openrobotics.org',
     description='TODO: Package description',
     license='TODO: License declaration',
-    tests_require=['pytest'],
+    extras_require={
+        'test'=['pytest'],
+    },
     entry_points={
         'console_scripts': [
             (

--- a/rmf_demos_bridges/setup.py
+++ b/rmf_demos_bridges/setup.py
@@ -20,7 +20,7 @@ setup(
     description='TODO: Package description',
     license='TODO: License declaration',
     extras_require={
-        'test'=['pytest'],
+        'test': ['pytest'],
     },
     entry_points={
         'console_scripts': [

--- a/rmf_demos_fleet_adapter/setup.py
+++ b/rmf_demos_fleet_adapter/setup.py
@@ -29,7 +29,9 @@ setup(
     description='Fleet adapters for interfacing with RMF Demos robots with a '
     'fleet manager via REST API',
     license='Apache License 2.0',
-    tests_require=['pytest'],
+    extras_require={
+        'test'=['pytest'],
+    },
     entry_points={
         'console_scripts': [
             'fleet_adapter=rmf_demos_fleet_adapter.fleet_adapter:main',

--- a/rmf_demos_fleet_adapter/setup.py
+++ b/rmf_demos_fleet_adapter/setup.py
@@ -30,7 +30,7 @@ setup(
     'fleet manager via REST API',
     license='Apache License 2.0',
     extras_require={
-        'test'=['pytest'],
+        'test': ['pytest'],
     },
     entry_points={
         'console_scripts': [

--- a/rmf_demos_tasks/rmf_demos_tasks/api_request.py
+++ b/rmf_demos_tasks/rmf_demos_tasks/api_request.py
@@ -52,6 +52,7 @@ class ApiRequester(Node):
         )
 
         self.args = parser.parse_args(argv[1:])
+        asyncio.set_event_loop(asyncio.new_event_loop())
         self.response = asyncio.Future()
 
         with open(self.args.file) as f:

--- a/rmf_demos_tasks/rmf_demos_tasks/cancel_robot_task.py
+++ b/rmf_demos_tasks/rmf_demos_tasks/cancel_robot_task.py
@@ -45,6 +45,7 @@ class TaskObserver(Node):
         super().__init__('TaskObserver')
 
         self.parser = parser
+        asyncio.set_event_loop(asyncio.new_event_loop())
         self.response = asyncio.Future()
 
         self.subscription = self.create_subscription(

--- a/rmf_demos_tasks/rmf_demos_tasks/dispatch_action.py
+++ b/rmf_demos_tasks/rmf_demos_tasks/dispatch_action.py
@@ -106,6 +106,7 @@ class TaskRequester(Node):
         )
 
         self.args = parser.parse_args(argv[1:])
+        asyncio.set_event_loop(asyncio.new_event_loop())
         self.response = asyncio.Future()
 
         transient_qos = QoSProfile(

--- a/rmf_demos_tasks/rmf_demos_tasks/dispatch_cart_delivery.py
+++ b/rmf_demos_tasks/rmf_demos_tasks/dispatch_cart_delivery.py
@@ -61,6 +61,7 @@ class TaskRequester(Node):
                             help='Use sim time, default: false')
 
         self.args = parser.parse_args(argv[1:])
+        asyncio.set_event_loop(asyncio.new_event_loop())
         self.response = asyncio.Future()
 
         transient_qos = QoSProfile(

--- a/rmf_demos_tasks/rmf_demos_tasks/dispatch_clean.py
+++ b/rmf_demos_tasks/rmf_demos_tasks/dispatch_clean.py
@@ -88,6 +88,7 @@ class TaskRequester(Node):
         )
 
         self.args = parser.parse_args(argv[1:])
+        asyncio.set_event_loop(asyncio.new_event_loop())
         self.response = asyncio.Future()
 
         transient_qos = QoSProfile(

--- a/rmf_demos_tasks/rmf_demos_tasks/dispatch_delivery.py
+++ b/rmf_demos_tasks/rmf_demos_tasks/dispatch_delivery.py
@@ -139,6 +139,7 @@ class TaskRequester(Node):
         )
 
         self.args = parser.parse_args(argv[1:])
+        asyncio.set_event_loop(asyncio.new_event_loop())
         self.response = asyncio.Future()
 
         # check user delivery arg inputs

--- a/rmf_demos_tasks/rmf_demos_tasks/dispatch_dynamic_event.py
+++ b/rmf_demos_tasks/rmf_demos_tasks/dispatch_dynamic_event.py
@@ -151,6 +151,7 @@ class TaskRequester(Node):
 
                 required.append(req_contents)
 
+        asyncio.set_event_loop(asyncio.new_event_loop())
         self.response = asyncio.Future()
 
         transient_qos = QoSProfile(

--- a/rmf_demos_tasks/rmf_demos_tasks/dispatch_go_to_place.py
+++ b/rmf_demos_tasks/rmf_demos_tasks/dispatch_go_to_place.py
@@ -116,6 +116,7 @@ class TaskRequester(Node):
         )
 
         self.args = parser.parse_args(argv[1:])
+        asyncio.set_event_loop(asyncio.new_event_loop())
         self.response = asyncio.Future()
 
         transient_qos = QoSProfile(

--- a/rmf_demos_tasks/rmf_demos_tasks/dispatch_json.py
+++ b/rmf_demos_tasks/rmf_demos_tasks/dispatch_json.py
@@ -90,6 +90,7 @@ class TaskRequester(Node):
         )
 
         self.args = parser.parse_args(argv[1:])
+        asyncio.set_event_loop(asyncio.new_event_loop())
         self.response = asyncio.Future()
 
         with open(self.args.file) as f:

--- a/rmf_demos_tasks/rmf_demos_tasks/dispatch_patrol.py
+++ b/rmf_demos_tasks/rmf_demos_tasks/dispatch_patrol.py
@@ -96,6 +96,7 @@ class TaskRequester(Node):
         )
 
         self.args = parser.parse_args(argv[1:])
+        asyncio.set_event_loop(asyncio.new_event_loop())
         self.response = asyncio.Future()
 
         transient_qos = QoSProfile(

--- a/rmf_demos_tasks/rmf_demos_tasks/dispatch_teleop.py
+++ b/rmf_demos_tasks/rmf_demos_tasks/dispatch_teleop.py
@@ -78,6 +78,7 @@ class TaskRequester(Node):
         )
 
         self.args = parser.parse_args(argv[1:])
+        asyncio.set_event_loop(asyncio.new_event_loop())
         self.response = asyncio.Future()
 
         transient_qos = QoSProfile(

--- a/rmf_demos_tasks/rmf_demos_tasks/get_robot_location.py
+++ b/rmf_demos_tasks/rmf_demos_tasks/get_robot_location.py
@@ -44,6 +44,7 @@ class RobotStateObserver(Node):
         super().__init__('TaskObserver')
 
         self.parser = parser
+        asyncio.set_event_loop(asyncio.new_event_loop())
         self.response = asyncio.Future()
 
         self.subscription = self.create_subscription(

--- a/rmf_demos_tasks/rmf_demos_tasks/teleop_robot.py
+++ b/rmf_demos_tasks/rmf_demos_tasks/teleop_robot.py
@@ -96,6 +96,7 @@ def main(argv=sys.argv):
     args_without_ros = rclpy.utilities.remove_ros_args(sys.argv)
     requester = Requester(args_without_ros)
 
+    asyncio.set_event_loop(asyncio.new_event_loop())
     timeout = asyncio.Future()
 
     def trigger_timeout():

--- a/rmf_demos_tasks/rmf_demos_tasks/wait_for_task_complete.py
+++ b/rmf_demos_tasks/rmf_demos_tasks/wait_for_task_complete.py
@@ -38,6 +38,7 @@ class TaskObserver(Node):
         super().__init__('TaskObserver')
 
         self.parser = parser
+        asyncio.set_event_loop(asyncio.new_event_loop())
         self.response = asyncio.Future()
 
         self.subscription = self.create_subscription(

--- a/rmf_demos_tasks/setup.py
+++ b/rmf_demos_tasks/setup.py
@@ -23,7 +23,7 @@ setup(
     description='A package containing scripts for demos',
     license='Apache License Version 2.0',
     extras_require={
-        'test'=['pytest'],
+        'test': ['pytest'],
     },
     entry_points={
         'console_scripts': [

--- a/rmf_demos_tasks/setup.py
+++ b/rmf_demos_tasks/setup.py
@@ -22,7 +22,9 @@ setup(
     maintainer_email='yadunund@openrobotics.org',
     description='A package containing scripts for demos',
     license='Apache License Version 2.0',
-    tests_require=['pytest'],
+    extras_require={
+        'test'=['pytest'],
+    },
     entry_points={
         'console_scripts': [
             'request_loop = rmf_demos_tasks.request_loop:main',

--- a/rmf_demos_tasks/setup.py
+++ b/rmf_demos_tasks/setup.py
@@ -38,8 +38,8 @@ setup(
             'dispatch_action = rmf_demos_tasks.dispatch_action:main',
             'dispatch_patrol = rmf_demos_tasks.dispatch_patrol:main',
             'dispatch_delivery = rmf_demos_tasks.dispatch_delivery:main',
-            'dispatch_cart_delivery = '
-                'rmf_demos_tasks.dispatch_cart_delivery:main',
+            'dispatch_cart_delivery = \
+                rmf_demos_tasks.dispatch_cart_delivery:main',
             'dispatch_clean = rmf_demos_tasks.dispatch_clean:main',
             'dispatch_go_to_place = rmf_demos_tasks.dispatch_go_to_place:main',
             'dispatch_teleop = rmf_demos_tasks.dispatch_teleop:main',


### PR DESCRIPTION
Part of https://github.com/open-rmf/rmf/issues/728, updating the `rmf_demos` repo to be compatible with the Lyrical distribution.

The key thing fixed in this PR is to address [the deprecation of `asyncio.get_event_loop` in Python](https://stackoverflow.com/questions/78577538/replacement-for-deprecated-asyncio-get-event-loop). We aren't using `asyncio.get_event_loop` directly, but apparently it's being used by the constructor of `asyncio.Future`.

The original behavior of `asyncio.get_event_loop` was to get whatever event loop is being used for the current thread, or create a new event loop if one isn't being used. Apparently this had a risk of subtle race conditions, so the behavior was changed to simply throw an exception if the current thread does not already have an event loop.

The fix in this PR is simple: Immediately before constructing an `asyncio.Future`, we create a new event loop and set it as the event loop of the current thread. In every script where `asyncio.Future` gets created, no event loop _would_ be created until _after_ `asyncio.Future` needs to be constructed. By creating and setting the event loop immediately before constructing the `asyncio.Future`, we ensure the event loop is ready to be used for the `asyncio.Future`. Later on rclpy will see that an event loop already exists and use the one we created instead of creating a new one.