### PR TITLE
Add robots dynamically during runtime

### DIFF
--- a/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/RobotClientAPI.py
+++ b/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/RobotClientAPI.py
@@ -55,6 +55,29 @@ class RobotAPI:
             return False
         return True
 
+    def add_robot(self, robot_name: str):
+        """
+        Request the fleet manager to add a new robot at runtime.
+
+        The robot is expected to already be spawned in map. Return True if
+        the robot is successfully added, else False.
+        """
+        url = (
+            self.prefix
+            + f'/open-rmf/rmf_demos_fm/add_robot?robot_name={robot_name}'
+        )
+        try:
+            response = requests.post(url, timeout=self.timeout)
+            response.raise_for_status()
+            if self.debug:
+                print(f'Response: {response.json()}')
+            return response.json()['success']
+        except HTTPError as http_err:
+            print(f'HTTP error for {robot_name} in add_robot: {http_err}')
+        except Exception as err:
+            print(f'Other error for {robot_name} in add_robot: {err}')
+        return False
+
     def navigate(
         self,
         robot_name: str,

--- a/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/fleet_adapter.py
+++ b/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/fleet_adapter.py
@@ -15,7 +15,6 @@
 import argparse
 import asyncio
 import faulthandler
-import json
 import math
 import sys
 import threading
@@ -33,12 +32,12 @@ from rclpy.qos import QoSReliabilityPolicy as Reliability
 import rmf_adapter
 from rmf_adapter import Adapter
 import rmf_adapter.easy_full_control as rmf_easy
+from rmf_demos_msgs.srv import AddRobot
 from rmf_fleet_msgs.msg import ClosedLanes
 from rmf_fleet_msgs.msg import LaneRequest
 from rmf_fleet_msgs.msg import ModeRequest
 from rmf_fleet_msgs.msg import RobotMode
 from rmf_fleet_msgs.msg import SpeedLimitRequest
-from rmf_fleet_msgs.srv import AddRobot
 import yaml
 
 from .RobotClientAPI import RobotAPI
@@ -524,16 +523,6 @@ def ros_connections(
             f'Received request to add robot [{robot_name}] at runtime'
         )
 
-        try:
-            cfg = json.loads(request.robot_config)
-            if not isinstance(cfg, dict):
-                raise ValueError('robot_config must be a JSON object')
-        except (json.JSONDecodeError, ValueError) as err:
-            response.success = False
-            response.message = f'Invalid robot_config JSON: {err}'
-            node.get_logger().error(response.message)
-            return response
-
         if not api.add_robot(robot_name):
             response.success = False
             response.message = (
@@ -543,9 +532,9 @@ def ros_connections(
             return response
 
         fleet_config.add_known_robot_configuration(
-            robot_name, 
+            robot_name,
             rmf_easy.RobotConfiguration(
-                compatible_chargers=cfg.get('compatible_chargers')
+                compatible_chargers=request.robot_config.compatible_chargers
             )
         )
         robot_config = fleet_config.get_known_robot_configuration(robot_name)

--- a/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/fleet_adapter.py
+++ b/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/fleet_adapter.py
@@ -534,12 +534,6 @@ def ros_connections(
             node.get_logger().error(response.message)
             return response
 
-        robot_config = rmf_easy.RobotConfiguration(
-            compatible_chargers=cfg.get('compatible_chargers')
-        )
-        fleet_config.add_known_robot_configuration(robot_name, robot_config)
-        robot_config = fleet_config.get_known_robot_configuration(robot_name)
-
         if not api.add_robot(robot_name):
             response.success = False
             response.message = (
@@ -547,6 +541,14 @@ def ros_connections(
             )
             node.get_logger().error(response.message)
             return response
+
+        fleet_config.add_known_robot_configuration(
+            robot_name, 
+            rmf_easy.RobotConfiguration(
+                compatible_chargers=cfg.get('compatible_chargers')
+            )
+        )
+        robot_config = fleet_config.get_known_robot_configuration(robot_name)
 
         robot_adapter = RobotAdapter(
             robot_name, robot_config, node, api, fleet_handle

--- a/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/fleet_adapter.py
+++ b/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/fleet_adapter.py
@@ -15,6 +15,7 @@
 import argparse
 import asyncio
 import faulthandler
+import json
 import math
 import sys
 import threading
@@ -37,6 +38,7 @@ from rmf_fleet_msgs.msg import LaneRequest
 from rmf_fleet_msgs.msg import ModeRequest
 from rmf_fleet_msgs.msg import RobotMode
 from rmf_fleet_msgs.msg import SpeedLimitRequest
+from rmf_fleet_msgs.srv import AddRobot
 import yaml
 
 from .RobotClientAPI import RobotAPI
@@ -135,6 +137,7 @@ def main(argv=sys.argv):
     )
 
     robots = {}
+    _lock = threading.Lock()
     for robot_name in fleet_config.known_robots:
         robot_config = fleet_config.get_known_robot_configuration(robot_name)
         robots[robot_name] = RobotAdapter(
@@ -149,9 +152,13 @@ def main(argv=sys.argv):
         while rclpy.ok():
             now = node.get_clock().now()
 
+            # lock as a concurrent /add_robot may mutate it.
+            with _lock:
+                current_robots = list(robots.values())
+
             # Update all the robots in parallel using a thread pool
             update_jobs = []
-            for robot in robots.values():
+            for robot in current_robots:
                 update_jobs.append(update_robot(robot))
 
             asyncio.get_event_loop().run_until_complete(
@@ -172,7 +179,9 @@ def main(argv=sys.argv):
     update_thread.start()
 
     # Connect to the extra ROS2 topics that are relevant for the adapter
-    connections = ros_connections(node, robots, fleet_handle)
+    connections = ros_connections(
+        node, robots, _lock, fleet_config, api, fleet_handle
+    )
     connections  # Avoid unused variable warning
 
     # Create executor for the command handle node
@@ -429,7 +438,9 @@ def update_robot(robot: RobotAdapter):
     robot.update(state, data)
 
 
-def ros_connections(node, robots, fleet_handle):
+def ros_connections(
+    node, robots, _lock, fleet_config, api, fleet_handle
+):
     fleet_name = fleet_handle.more().fleet_name
 
     transient_qos = QoSProfile(
@@ -497,6 +508,59 @@ def ros_connections(node, robots, fleet_handle):
                 return
             robot.finish_action()
 
+    def handle_add_robot(request, response):
+        robot_name = request.robot_name.strip()
+        if (
+            not robot_name
+            or robot_name in robots
+            or not request.robot_config
+        ):
+            response.success = False
+            response.message = 'Invalid request'
+            node.get_logger().error(response.message)
+            return response
+
+        node.get_logger().info(
+            f'Received request to add robot [{robot_name}] at runtime'
+        )
+
+        try:
+            cfg = json.loads(request.robot_config)
+            if not isinstance(cfg, dict):
+                raise ValueError('robot_config must be a JSON object')
+        except (json.JSONDecodeError, ValueError) as err:
+            response.success = False
+            response.message = f'Invalid robot_config JSON: {err}'
+            node.get_logger().error(response.message)
+            return response
+
+        robot_config = rmf_easy.RobotConfiguration(
+            compatible_chargers=cfg.get('compatible_chargers')
+        )
+        fleet_config.add_known_robot_configuration(robot_name, robot_config)
+        robot_config = fleet_config.get_known_robot_configuration(robot_name)
+
+        if not api.add_robot(robot_name):
+            response.success = False
+            response.message = (
+                f'Fleet manager rejected registration of {robot_name}'
+            )
+            node.get_logger().error(response.message)
+            return response
+
+        robot_adapter = RobotAdapter(
+            robot_name, robot_config, node, api, fleet_handle
+        )
+        with _lock:
+            robots[robot_name] = robot_adapter
+
+        response.success = True
+        response.message = (
+            f'Robot {robot_name} successfully added'
+        )
+        node.get_logger().info(response.message)
+        return response
+
     lane_request_sub = node.create_subscription(
         LaneRequest,
         'lane_closure_requests',
@@ -518,10 +582,17 @@ def ros_connections(node, robots, fleet_handle):
         qos_profile=qos_profile_system_default,
     )
 
+    add_robot_srv = node.create_service(
+        AddRobot,
+        f'{fleet_name}/add_robot',
+        handle_add_robot
+    )
+
     return [
         lane_request_sub,
         speed_limit_request_sub,
         action_execution_notice_sub,
+        add_robot_srv,
     ]
 
 

--- a/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/fleet_manager.py
+++ b/rmf_demos_fleet_adapter/rmf_demos_fleet_adapter/fleet_manager.py
@@ -117,6 +117,8 @@ class FleetManager(Node):
         self.robots = {}  # Map robot name to state
         self.action_paths = {}  # Map activities to paths
 
+        self._lock = threading.Lock()
+
         for robot_name, _ in self.config['rmf_fleet']['robots'].items():
             self.robots[robot_name] = State()
         assert len(self.robots) > 0
@@ -211,21 +213,40 @@ class FleetManager(Node):
         @app.get('/open-rmf/rmf_demos_fm/status/', response_model=Response)
         async def status(robot_name: Optional[str] = None):
             response = {'data': {}, 'success': False, 'msg': ''}
-            if robot_name is None:
-                response['data']['all_robots'] = []
-                for robot_name in self.robots:
+            with self._lock:
+                if robot_name is None:
+                    response['data']['all_robots'] = []
+                    for robot_name in self.robots:
+                        state = self.robots.get(robot_name)
+                        if state is None or state.state is None:
+                            return response
+                        response['data']['all_robots'].append(
+                            self.get_robot_state(state, robot_name)
+                        )
+                else:
                     state = self.robots.get(robot_name)
                     if state is None or state.state is None:
                         return response
-                    response['data']['all_robots'].append(
-                        self.get_robot_state(state, robot_name)
-                    )
-            else:
-                state = self.robots.get(robot_name)
-                if state is None or state.state is None:
-                    return response
-                response['data'] = self.get_robot_state(state, robot_name)
+                    response['data'] = self.get_robot_state(state, robot_name)
             response['success'] = True
+            return response
+
+        @app.post('/open-rmf/rmf_demos_fm/add_robot/', response_model=Response)
+        async def add_robot(robot_name: str):
+            response = {'success': False, 'msg': ''}
+            robot_name = robot_name.strip()
+            if not robot_name:
+                response['msg'] = 'robot_name must not be empty'
+                return response
+
+            with self._lock:
+                if robot_name in self.robots:
+                    response['msg'] = f'Robot {robot_name} already exists'
+                    return response
+
+                self.robots[robot_name] = State()
+            response['success'] = True
+            response['msg'] = f'Robot {robot_name} added'
             return response
 
         @app.post('/open-rmf/rmf_demos_fm/navigate/', response_model=Response)

--- a/rmf_demos_maps/maps/office/office.building.yaml
+++ b/rmf_demos_maps/maps/office/office.building.yaml
@@ -1,7 +1,7 @@
 coordinate_system: reference_image
 crowd_sim:
   agent_groups:
-    - {agents_name: [tinyRobot1, tinyRobot2], agents_number: 2, group_id: 0, profile_selector: external_agent, state_selector: external_static, x: 0, y: 0}
+    - {agents_name: [tinyRobot1, tinyRobot2, tinyRobot3], agents_number: 3, group_id: 0, profile_selector: external_agent, state_selector: external_static, x: 0, y: 0}
   agent_profiles:
     - {ORCA_tau: 1, ORCA_tauObst: 0.40000000000000002, class: 1, max_accel: 0, max_angle_vel: 0, max_neighbors: 10, max_speed: 0, name: external_agent, neighbor_dist: 5, obstacle_set: 1, pref_speed: 0, r: 0.25}
   enable: 0
@@ -253,7 +253,7 @@ levels:
       - [1366.239, 826.50900000000001, 0, ""]
       - [1807.172, 818.48000000000002, 0, ""]
       - [1365.1089999999999, 1120.3630000000001, 0, ""]
-      - [1791.0930000000001, 1110.8050000000001, 0, ""]
+      - [1791.0930000000001, 1110.8050000000001, 0, tinyRobot3_charger, {is_charger: [4, true], is_holding_point: [4, true], is_parking_spot: [4, true], spawn_robot_name: [1, tinyRobot3], spawn_robot_type: [1, Open-RMF/TinyRobot]}]
       - [769.86699999999996, 618.14800000000002, 0, ""]
       - [2016.125, 1310.9549999999999, 0, ""]
       - [2468.096, 1217.693, 0, ""]

--- a/rmf_demos_msgs/CMakeLists.txt
+++ b/rmf_demos_msgs/CMakeLists.txt
@@ -1,0 +1,36 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(rmf_demos_msgs)
+
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  # we dont use add_compile_options with pedantic in message packages
+  # because the Python C extensions dont comply with it
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic")
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(builtin_interfaces REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+
+set(msg_files
+  "msg/RobotConfiguration.msg"
+)
+
+set(srv_files
+  "srv/AddRobot.srv"
+)
+
+rosidl_generate_interfaces(${PROJECT_NAME}
+  ${msg_files}
+  ${srv_files}
+  DEPENDENCIES builtin_interfaces
+  ADD_LINTER_TESTS
+)
+
+ament_export_dependencies(rosidl_default_runtime)
+
+ament_package()

--- a/rmf_demos_msgs/README.md
+++ b/rmf_demos_msgs/README.md
@@ -1,0 +1,5 @@
+# rmf_demos_msgs
+
+`rmf_demos_msgs` provides message types for interacting with robot fleet adapters.
+
+For more information about ROS 2 interfaces, see [docs.ros.org](https://docs.ros.org/en/jazzy/Concepts/Basic/About-Interfaces.html)

--- a/rmf_demos_msgs/msg/RobotConfiguration.msg
+++ b/rmf_demos_msgs/msg/RobotConfiguration.msg
@@ -1,0 +1,7 @@
+string[] compatible_chargers
+
+bool responsive_wait # default: None
+
+float32 max_merge_waypoint_distance # default: 1e-3
+float32 max_merge_lane_distance # default: 0.3
+float32 min_lane_length # default: 1e-8

--- a/rmf_demos_msgs/package.xml
+++ b/rmf_demos_msgs/package.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>rmf_demos_msgs</name>
+  <version>0.0.0</version>
+  <description>A package containing messages used in demos</description>
+  <maintainer email="xiyu@openrobotics.org">Xi Yu Oh</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <buildtool_depend>rosidl_default_generators</buildtool_depend>
+
+  <build_depend>builtin_interfaces</build_depend>
+
+  <exec_depend>builtin_interfaces</exec_depend>
+  <exec_depend>rosidl_default_runtime</exec_depend>
+
+  <test_depend>ament_lint_common</test_depend>
+
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/rmf_demos_msgs/srv/AddRobot.srv
+++ b/rmf_demos_msgs/srv/AddRobot.srv
@@ -1,0 +1,7 @@
+# Name of the robot to be added
+string robot_name
+
+RobotConfiguration robot_config
+---
+bool success
+string message


### PR DESCRIPTION
## New feature implementation

### Implemented feature

Add robots dynamically during runtime.

### Implementation description

Refer to this [issue](https://github.com/open-rmf/rmf_ros2/issues/523). Requires this `rmf_internal_msgs` [PR](https://github.com/open-rmf/rmf_internal_msgs/pull/95).

This PR implements runtime robot registration in the `rmf_demos` fleet adapter and fleet manager, adding a robot to a running fleet without restarting the adapter. This demonstrates how a user can potentially write a similar service callback in their fleet adapter to achieve the same results.

### How to test

I've added a third robot `tinyRobot3` using an existing point in the map as charger/spawn point so the office demo can be used to exercise adding a robot at runtime. We can alternatively create a new demo map for this feature if needed.

Launch office demo
`ros2 launch rmf_demos_gz office.launch.xml`

Call service
`ros2 service call /tinyRobot/add_robot rmf_fleet_msgs/srv/AddRobot \
    "{robot_name: 'tinyRobot3', robot_config: '{\"compatible_chargers\": [\"tinyRobot3_charger\"]}'}"`


### GenAI Use
We follow [OSRA's policy on GenAI tools](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md)

- [x] I used a GenAI tool in this PR.
- [ ] I did not use GenAI

Generated-by: Claude Opus 4.8