### PR TITLE
rmf_demos_tasks: Fix typo in license name in package.xml

### DIFF
--- a/rmf_demos_tasks/package.xml
+++ b/rmf_demos_tasks/package.xml
@@ -7,7 +7,7 @@
   <author email= "grey@openrobotics.org">Grey</author>
   <maintainer email="yadunund@openrobotics.org">Yadunund</maintainer>
   <maintainer email="marco@openrobotics.org">Marco A. Gutiérrez</maintainer>
-  <license>Apache Licence 2.0</license>
+  <license>Apache License 2.0</license>
 
   <exec_depend>rmf_fleet_msgs</exec_depend>
   <exec_depend>rmf_task_msgs</exec_depend>


### PR DESCRIPTION


## Bug fix

### Fixed bug

On RoboStack recipe generation (see https://github.com/RoboStack/ros-rolling/pull/31) we had an annoying warning:

~~~
2026-08-20T10:36:11.7489110Z Warning: License 'Apache Licence 2.0' in package 'rmf_demos_tasks' is not a recognized SPDX identifier. Using 'LicenseRef-Apache-Licence-2.0' instead.
~~~

that I think was due to a type in the license in the package.xml .

### Fix applied

Fix the typo.


### GenAI Use
We follow [OSRA's policy on GenAI tools](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md)

- [ ] I used a GenAI tool in this PR.
- [x] I did not use GenAI

Generated-by:
